### PR TITLE
Fixes #1025 (NaN in history tab)

### DIFF
--- a/src/jade/tabs/history.jade
+++ b/src/jade/tabs/history.jade
@@ -39,12 +39,12 @@ section.panel.content(ng-controller="HistoryCtrl")
           form(ng-submit="submitDateRangeForm()")
             label.input-append.date
               span From
-              input(type="text", rp-datepicker, ng-model="dateMinView", readonly)
+              input(type="text", rp-datepicker, ignore-invalid-update='1',  ng-model="dateMinView", readonly)
               span.add-on
                 i.icon-calendar
             label.input-append.date
               span To
-              input(type="text", rp-datepicker, ng-model="dateMaxView", readonly)
+              input(type="text", rp-datepicker, ignore-invalid-update='1',  ng-model="dateMaxView", readonly)
               span.add-on
                 i.icon-calendar
             button.btn.submit(type='submit') Filter

--- a/src/js/directives/fields.js
+++ b/src/js/directives/fields.js
@@ -194,9 +194,19 @@ module.directive('rpDatepicker', [function() {
             ngModel.$setViewValue(e.date.getMonth() ? e.date : new Date(e.date));
           });
         });
-        scope.$watch(attr.ngModel,function(){
-          dp.datepicker('setValue',ngModel.$viewValue)
-            .datepicker('update');
+        scope.$watch(attr.ngModel,function() {
+          var update = ngModel.$viewValue;
+
+          function falsy(v) {return v == '0' || v == 'false'; }
+
+          if (!falsy(attr.ignoreInvalidUpdate) &&
+               (update == null ||
+                 (update instanceof Date && isNaN(update.getYear())) )) {
+              return;
+            } else {
+              dp.datepicker('setValue', update)
+                .datepicker('update');
+            }
         });
       });
     }

--- a/src/js/tabs/history.js
+++ b/src/js/tabs/history.js
@@ -310,8 +310,8 @@ HistoryTab.prototype.angular = function (module) {
         });
 
         if ($scope.historyShow.length && !$scope.dateMinView) {
-          $scope.dateMinView = new Date(dateMin);
-          $scope.dateMaxView = new Date(dateMax);
+          setValidDateOnScopeOrNullify('dateMinView', dateMin);
+          setValidDateOnScopeOrNullify('dateMaxView', dateMax);
         }
       }
     };
@@ -342,6 +342,14 @@ HistoryTab.prototype.angular = function (module) {
         $scope.filters.currencies = objCurrencies;
       }
     };
+
+    var setValidDateOnScopeOrNullify = function(key, value) {
+      if (isNaN(value) || value == null) {
+        $scope[key] = null;
+      } else {
+        $scope[key] = new Date(value);
+      }
+    }
 
     $scope.loadMore = function () {
       var dateMin;
@@ -384,7 +392,7 @@ HistoryTab.prototype.angular = function (module) {
 
             $scope.historyState = ($scope.history.length === newHistory.length) ? 'full' : 'ready';
             $scope.history = newHistory;
-            $scope.dateMinView = new Date(dateMin);
+            setValidDateOnScopeOrNullify('dateMinView', dateMin);
           }
         });
       }).request();


### PR DESCRIPTION
This patch makes sure to set the `dateMinView` for transaction history filtering to a falsy value so will recompute. Any such falsy values are ignored by the datepicker directive such that it will show blank, or the last valid value. Perhaps not ideal but less unsightly than NaN.
