### PR TITLE
Fixing the trade orders to not repeat the amount.

### DIFF
--- a/src/jade/tabs/history.jade
+++ b/src/jade/tabs/history.jade
@@ -130,7 +130,7 @@ section.col-xs-12.content(ng-controller="HistoryCtrl")
                 != require("./history/effects.jade")()
               span(ng-switch-when="offernew")
                 span(ng-show="entry.transaction.sell", l10n, rp-span-spacing) You created an order to sell
-                  span.amount(rp-pretty-amount="entry.transaction.pays")
+                  span.amount(rp-pretty-amount="entry.transaction.gets")
                   | for
                   span.amount(rp-pretty-amount="entry.transaction.pays")
                 span(ng-hide="entry.transaction.sell", l10n, rp-span-spacing) You created an order to buy


### PR DESCRIPTION
Was seeing text "You created an order to sell 2,000 XRP for 2,000 XRP" when I was expecting "You created an order to sell 10 USD for 2,000 XRP". 

See: [WC-1680](https://ripplelabs.atlassian.net/browse/WC-1680) Orders in the Transaction History are incorrect
