### PR TITLE
Added instructions for config.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,13 @@ This is a general purpose Ripple client in JavaScript.
         $ cd ripple-client
         $ npm install
 
-4. Create your config file
+4. Create your config.js file
         
         $ cp src/js/config-example.js src/js/config.js
+
+5. Create your config.json file
+        
+        $ cp config-example.json config.json
 
 ## Build
 Run the following command to build the client.    


### PR DESCRIPTION
Without the config.json file, the following error message is generated when building with grunt:
Error: Unable to read "config.json" file (Error code: ENOENT)
