### PR TITLE
Registration works when there is no old blobvault

### DIFF
--- a/src/js/services/oldblob.js
+++ b/src/js/services/oldblob.js
@@ -165,6 +165,7 @@ module.factory('rpOldBlob', ['$rootScope', function ($scope)
 
     get: function (key, callback) {
       var url = Options.blobvault;
+      if(!url) return;
 
       if (url.indexOf("://") === -1) url = "http://" + url;
 
@@ -180,6 +181,7 @@ module.factory('rpOldBlob', ['$rootScope', function ($scope)
 
     set: function (key, value, callback) {
       var url = Options.blobvault;
+      if(!url) return;
 
       if (url.indexOf("://") === -1) url = "http://" + url;
 


### PR DESCRIPTION
If we don't configure an old blobvault, then just ignore calls to
operate on it.
