### PR TITLE
Fix currency parsing

### DIFF
--- a/src/js/tabs/exchange.js
+++ b/src/js/tabs/exchange.js
@@ -54,7 +54,7 @@ ExchangeTab.prototype.angular = function (module)
       $scope.update_exchange = function () {
         var exchange = $scope.exchange;
         var currency = exchange.currency_code;
-        var formatted = "" + exchange.amount + " " + currency.slice(0, 3);
+        var formatted = "" + currency.slice(0,3) + " " + exchange.amount;
 
         $scope.reset_paths();
 
@@ -194,7 +194,7 @@ ExchangeTab.prototype.angular = function (module)
        */
       $scope.exchange_confirmed = function () {
         var currency = $scope.exchange.currency.slice(0, 3).toUpperCase();
-        var amount = Amount.from_human(""+$scope.exchange.amount+" "+currency);
+        var amount = Amount.from_human(""+currency+" "+$scope.exchange.amount);
 
         amount.set_issuer($id.account);
 

--- a/src/js/tabs/send.js
+++ b/src/js/tabs/send.js
@@ -67,7 +67,8 @@ SendTab.prototype.angular = function (module)
     }, true);
 
     $scope.$watch('send.currency', function () {
-      $scope.send.currency_code = ripple.Currency.from_json($scope.send.currency).to_human().toUpperCase();
+      var match = /^([a-zA-Z0-9]{3}|[A-Fa-f0-9]{40})\b/.exec($scope.send.currency);
+      $scope.send.currency_code = ripple.Currency.from_json(match[0]).to_human().toUpperCase();
       $scope.update_currency();
     }, true);
 
@@ -406,7 +407,7 @@ SendTab.prototype.angular = function (module)
       // this actually *causes* the same odd rounding problem, so in the future
       // we'll want a better solution, but for right now this does what we need.
       var refDate = new Date(new Date().getTime() + 5 * 60000);
-      var amount = send.amount_feedback = ripple.Amount.from_human('' + send.amount + ' ' + currency.toUpperCase(), { reference_date: refDate });
+      var amount = send.amount_feedback = ripple.Amount.from_human('' + currency.toUpperCase() + ' ' + send.amount, { reference_date: refDate });
 
       $scope.reset_amount_deps();
       send.path_status = 'waiting';

--- a/src/js/tabs/trade.js
+++ b/src/js/tabs/trade.js
@@ -312,7 +312,7 @@ TradeTab.prototype.angular = function(module)
     $scope.update_first = function (type) {
       var order = $scope.order[type];
       var first_currency = $scope.order.first_currency || Currency.from_json("XRP");
-      var formatted = "" + order.first + " " + first_currency.to_json();
+      var formatted = "" + first_currency.to_json() + " " + order.first;
 
       order.first_amount = ripple.Amount.from_human(formatted, {reference_date: new Date(+new Date() + 5*60000)});
 
@@ -322,7 +322,7 @@ TradeTab.prototype.angular = function(module)
     $scope.update_price = function (type) {
       var order = $scope.order[type];
       var second_currency = $scope.order.second_currency || Currency.from_json("XRP");
-      var formatted = "" + order.price + " " + second_currency.to_json();
+      var formatted = "" + second_currency.to_json() + " " + order.price;
 
       order.price_amount = ripple.Amount.from_human(formatted, {reference_date: new Date(+new Date() + 5*60000)});
 
@@ -332,7 +332,7 @@ TradeTab.prototype.angular = function(module)
     $scope.update_second = function (type) {
       var order = $scope.order[type];
       var second_currency = $scope.order.second_currency || Currency.from_json("XRP");
-      var formatted = "" + order.second + " " + second_currency.to_json();
+      var formatted = "" + second_currency.to_json() + " " + order.second;
 
       order.second_amount = ripple.Amount.from_human(formatted, {reference_date: new Date(+new Date() + 5*60000)});
 

--- a/src/js/tabs/trust.js
+++ b/src/js/tabs/trust.js
@@ -120,7 +120,7 @@ TrustTab.prototype.angular = function (module)
               return;
             }
             var currency = match[1];
-            var amount = ripple.Amount.from_human('' + $scope.amount + ' ' + currency.toUpperCase(), {reference_date: new Date(+new Date() + 5*60000)});
+            var amount = ripple.Amount.from_human('' + currency.toUpperCase() + ' ' + $scope.amount, {reference_date: new Date(+new Date() + 5*60000)});
             amount.set_issuer($scope.counterparty_address);
             if (!amount.is_valid()) {
               // Invalid amount. Indicates a bug in one of the validators.


### PR DESCRIPTION
All the uses of from_human were backwards as compared to the ripple-lib
docs and this was sometimes causing prices to be computed in XRP even
when the user specified some other currency.
