### PR TITLE
[FIX] Send: Make ripple address reappear below the recipient field

### DIFF
--- a/src/jade/tabs/send.jade
+++ b/src/jade/tabs/send.jade
@@ -18,7 +18,7 @@ section.single.content(ng-controller='SendCtrl')
     ng-submit='send_prepared()')
     p.literal(l10n) Send money on the Ripple network.
     hr
-    .row.form-group(ng-show="'web' === client")
+    .row.form-group(ng-if="'web' === client")
       .col-xs-12.col-sm-6.col-md-5
         label(for='send_destination', l10n) Recipient
         input.form-control#send_destination(
@@ -40,7 +40,7 @@ section.single.content(ng-controller='SendCtrl')
             | Recipient should be a Ripple name, a contact, or Ripple/Bitcoin address.
           .error(rp-error-on='federation', l10n)
             | This email address is not Ripple-enabled.
-    .row.form-group(ng-show="'desktop' === client")
+    .row.form-group(ng-if="'desktop' === client")
       .col-xs-12.col-sm-6.col-md-5
         label(for='send_destination', l10n) Recipient
         input.form-control#send_destination(


### PR DESCRIPTION
Replace ng-show with ng-if for send_destination field. The rpDest directive was not working because the page had two send_destination fields with the same name.
