### PR TITLE
Registration should not assume there is an oldblob

### DIFF
--- a/src/js/services/id.js
+++ b/src/js/services/id.js
@@ -270,14 +270,16 @@ module.factory('rpId', ['$rootScope', '$location', '$route', '$routeParams',
       }
 
       // Remove old blob
-      $oldblob.remove(['vault', 'local'], opts.oldUsername, opts.oldPassword, function (err, data) {
-        if (err) {
-          console.log("Can't delete the old blobvault:", err);
-          return;
-        }
+      if(Options.blobvault) {
+        $oldblob.remove(['vault', 'local'], opts.oldUsername, opts.oldPassword, function (err, data) {
+          if (err) {
+            console.log("Can't delete the old blobvault:", err);
+            return;
+          }
 
-        console.log('Old blob has been removed.');
-      });
+          console.log('Old blob has been removed.');
+        });
+      }
 
       store.set('ripple_known', true);
       callback(null, masterkey);


### PR DESCRIPTION
This change checks first if we have an old blobvault configured, and
only issues the remove command in that case.

Replacement for #1201 fixing the real issue.
