### PR TITLE
Login errors were not always showing up

### DIFF
--- a/src/js/tabs/login.js
+++ b/src/js/tabs/login.js
@@ -121,6 +121,7 @@ LoginTab.prototype.angular = function (module) {
               'Message': err.message
             });
 
+            $scope.$apply();
             return;
           }
 


### PR DESCRIPTION
This fix makes sure changes to the scope are noticed by angular in the
setImmidiate context for login errors.
