### PR TITLE
[FIX] keychain: unlock duration not properly set

### DIFF
--- a/src/js/services/keychain.js
+++ b/src/js/services/keychain.js
@@ -196,7 +196,7 @@ module.factory('rpKeychain', ['$rootScope', '$timeout', 'rpPopup', 'rpId',
       if (_this.secrets[account] && !$scope.userBlob.data.persistUnlock) {
         delete _this.secrets[account];  
       }  
-    }, this.unlockDuration);  
+    }, Keychain.unlockDuration);  
   }
   
   return new Keychain();


### PR DESCRIPTION
The result of this appears that the secret got deleted immediately after it was requested, as the timeout parameter was set as 'undefined'
