### PR TITLE
[TASK] l10n: Page bottom change italian to japanese

### DIFF
--- a/src/jade/client/index.jade
+++ b/src/jade/client/index.jade
@@ -54,7 +54,7 @@ div#wrapper
         a(href="https://ripplelabs.atlassian.net/browse/WC", target="_blank", l10n) Bug reports
         a(href="#/lang/en") English
         a(href="#/lang/cn") 中文
-        a(href="#/lang/it") Italiano
+        a(href="#/lang/ja") 日本語
 
         // Language selector
         rp-popup


### PR DESCRIPTION
On bottom right of ripple trade screen, change the 3rd language option that is
always visible to Japanese from Italian. #deliver rt-1924
