### PR TITLE
[FIX] RT-1206: Detect browser language preferences

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,6 +2,8 @@ var path = require("path"),
     fs = require("fs"),
     languages = require("./l10n/languages.json").active;
 
+var languageCodes = languages.map(function(i) { return i.code; }).join(' ');
+
 var BannerPlugin = require("webpack/lib/BannerPlugin");
 
 module.exports = function(grunt) {
@@ -252,7 +254,8 @@ module.exports = function(grunt) {
           context: {
             MODE: "release",
             TARGET: "web",
-            VERSION: "<%= meta.version %>"
+            VERSION: "<%= meta.version %>",
+            LANGUAGES: languageCodes
           }
         }
       },
@@ -263,7 +266,8 @@ module.exports = function(grunt) {
           context: {
             MODE: "debug",
             TARGET: "web",
-            VERSION: "<%= meta.version %>"
+            VERSION: "<%= meta.version %>",
+            LANGUAGES: languageCodes
           }
         }
       },
@@ -274,7 +278,8 @@ module.exports = function(grunt) {
           context: {
             MODE: "release",
             TARGET: "desktop",
-            VERSION: "<%= meta.version %>"
+            VERSION: "<%= meta.version %>",
+            LANGUAGES: languageCodes
           }
         }
       },
@@ -285,7 +290,8 @@ module.exports = function(grunt) {
           context: {
             MODE: "debug",
             TARGET: "desktop",
-            VERSION: "<%= meta.version %>"
+            VERSION: "<%= meta.version %>",
+            LANGUAGES: languageCodes
           }
         }
       }

--- a/src/index.html
+++ b/src/index.html
@@ -118,7 +118,26 @@
 
   <script>
     window.name = 'NG_DEFER_BOOTSTRAP!';
-    var lang = store.get('ripple_language') || 'en';
+    var lang = (function(){
+      var languages = "<!-- @echo LANGUAGES -->".split(" ");
+      var languagesMap = { "zh": "cn" };
+      var resolveLanguage = function(lang) {
+        if (!lang) return null;
+        
+        lang = lang.toLowerCase();
+        if (languages.indexOf(lang) != -1) return lang;
+        if (lang.indexOf("-") != -1) {
+          lang = lang.split("-")[0];
+          if (languages.indexOf(lang) != -1) return lang;
+          if (languagesMap[lang]) return languagesMap[lang];
+        }
+        return null;
+      };
+
+      return resolveLanguage(store.get('ripple_language')) ||
+             resolveLanguage(window.navigator.userLanguage || window.navigator.language) ||
+             "en";
+    })();
     var debug = false;
   </script>
 


### PR DESCRIPTION
1. Detect user's browser language settings, and if we have a translation available in that language, display client in that language
2. If we don't have a translation available, display client in English
3. If a invalid language was selected (such as navigate to `#/lang/abcdefg`), display client in default language ( as 1 & 2).
- For languages with variants such as `zh-CN` and `en-US`, we will treat thoses as `zh` and `en`.
- A language alias map is introduced as the browser uses `zh` for Chinese but we use `cn` for Chinese.
