### PR TITLE
[FIX] Trade filter on history page

### DIFF
--- a/src/js/tabs/history.js
+++ b/src/js/tabs/history.js
@@ -63,7 +63,7 @@ HistoryTab.prototype.angular = function (module) {
         'checked': true
       },
       orders: {
-        'types': ['offernew','offercancel','exchange'],
+        'types': ['offernew','offercancel'],
         'checked': true
       },
       other: {
@@ -293,6 +293,10 @@ HistoryTab.prototype.angular = function (module) {
             // Trade filter - remove open orders that haven't been filled/partially filled
             if (_.contains($scope.filters.types,'exchange') && !_.contains($scope.filters.types,'offercancel')) {
               if (event.transaction && event.transaction.type === 'offernew' && !isTrade)
+                return
+            } else if (!_.contains($scope.filters.types,'exchange') && _.contains($scope.filters.types,'offercancel')) {
+              // Remove filled/partially filled orders with 'orders' filter
+              if (isTrade)
                 return
             }
 


### PR DESCRIPTION
Trade filter shows only partially/fully funded trades. I would call this a feature, but it's classified as a bug in Jira - hence the [FIX] label.

[Jira RT-1835](https://ripplelabs.atlassian.net/browse/RT-1835)
[Bountysource](https://www.bountysource.com/issues/2842682-create-trade-filter-in-history-tab)
