### PR TITLE
[FEATURE] Place recently used currency pairs on top (RT-1876)

### DIFF
--- a/src/js/controllers/app.js
+++ b/src/js/controllers/app.js
@@ -578,7 +578,15 @@ module.controller('AppCtrl', ['$rootScope', '$compile', 'rpId', 'rpNetwork',
 
   // sort currencies and pairs by order
   $scope.currencies_all.sort(compare);
-  $scope.pairs_all.sort(compare);
+
+  function compare_last_used(a, b) {
+    var time_a = a.last_used || a.order || 0;
+    var time_b = b.last_used || b.order || 0;
+    if (time_a < time_b) return 1;
+    if (time_a > time_b) return -1;
+    return 0;
+  }
+  $scope.pairs_all.sort(compare_last_used);
 
   $scope.currencies_all_keyed = {};
   _.each($scope.currencies_all, function(currency){

--- a/src/js/data/pairs.js
+++ b/src/js/data/pairs.js
@@ -8,26 +8,26 @@
  */
 
 var DEFAULT_PAIRS = [
-  {name: 'XAU (-0.5%pa)/XRP', order: 2},
-  {name: 'XAU (-0.5%pa)/USD', order: 2},
-  {name: 'BTC/XRP', order: 1},
-  {name: 'XRP/USD', order: 1},
-  {name: 'XRP/EUR', order: 1},
-  {name: 'XRP/JPY', order: 0},
-  {name: 'XRP/GBP', order: 0},
-  {name: 'XRP/AUD', order: 0},
-  {name: 'XRP/CHF', order: 0},
-  {name: 'XRP/CAD', order: 0},
-  {name: 'XRP/CNY', order: 0},
-  {name: 'XRP/MXN', order: 0},
-  {name: 'BTC/USD', order: 0},
-  {name: 'BTC/EUR', order: 0},
-  {name: 'EUR/USD', order: 0},
-  {name: 'USD/JPY', order: 0},
-  {name: 'GBP/USD', order: 0},
-  {name: 'AUD/USD', order: 0},
-  {name: 'USD/MXN', order: 0},
-  {name: 'USD/CHF', order: 0}
+  {name: 'XAU (-0.5%pa)/XRP', last_used: 2},
+  {name: 'XAU (-0.5%pa)/USD', last_used: 2},
+  {name: 'BTC/XRP', last_used: 1},
+  {name: 'XRP/USD', last_used: 1},
+  {name: 'XRP/EUR', last_used: 1},
+  {name: 'XRP/JPY', last_used: 0},
+  {name: 'XRP/GBP', last_used: 0},
+  {name: 'XRP/AUD', last_used: 0},
+  {name: 'XRP/CHF', last_used: 0},
+  {name: 'XRP/CAD', last_used: 0},
+  {name: 'XRP/CNY', last_used: 0},
+  {name: 'XRP/MXN', last_used: 0},
+  {name: 'BTC/USD', last_used: 0},
+  {name: 'BTC/EUR', last_used: 0},
+  {name: 'EUR/USD', last_used: 0},
+  {name: 'USD/JPY', last_used: 0},
+  {name: 'GBP/USD', last_used: 0},
+  {name: 'AUD/USD', last_used: 0},
+  {name: 'USD/MXN', last_used: 0},
+  {name: 'USD/CHF', last_used: 0}
 ];
 
 module.exports = DEFAULT_PAIRS;

--- a/src/js/directives/fields.js
+++ b/src/js/directives/fields.js
@@ -38,7 +38,11 @@ module.directive('rpCombobox', [function () {
         selectEl.click(function () {
           var complFn = scope.$eval(attrs.rpCombobox);
           if ("function" !== typeof complFn) {
+            var options = complFn;
             complFn = webutil.queryFromOptions(complFn);
+            scope.$watch(options, function(value) {
+              setCompletions(complFn());
+            });
           }
           setCompletions(complFn());
           if (cplEl.is(':visible')) {


### PR DESCRIPTION
- Change to "recently used" instead of "recently traded".
- Add watch in rpCombobox in order to update list at once.

[BountySource](https://www.bountysource.com/issues/2842748-ripple-trade-place-recently-used-currency-pairs-on-the-top-of-the-drop-menu)
[RT-1876](https://ripplelabs.atlassian.net/browse/RT-1876)
