### PR TITLE
Integrate Travis with Gitter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,9 @@ script: "grunt && npm run test-travis"
 notifications:
   email:
     false
+  webhooks:
+    urls:
+      - https://webhooks.gitter.im/e/706809d6a4c29c8fb8b6
+    on_success: change
+    on_failure: always
+    on_start: false


### PR DESCRIPTION
Add webhooks so CI results get reported to our [Gitter channel](https://gitter.im/ripple/developers).

This is just a test - we'll see if the integration is useful or spammy and based on that enable the other projects or not.
