### PR TITLE
[FIX] Unfunded banner flicker (RT-2064)

### DIFF
--- a/src/jade/client/navbar.jade
+++ b/src/jade/client/navbar.jade
@@ -147,7 +147,7 @@ nav.navbar(role="navigation", ng-controller="NavbarCtrl")
   div.auth-attention.banner.text-center(ng-if="recovered", ng-show="recovered", l10n) 
     h4(l10n) Your account was successfully recovered and encrypted with the new password you provided!
     a(href="#", ng-click="recovered = false", l10n) dismiss
-  div.auth-attention.banner(ng-show="'web' === client && !loadingAccount && !account.Balance && connected")
+  div.auth-attention.banner(ng-show="'web' === client && !loadingAccount && !account.Balance && loadState.account && connected")
     h4(l10n) Welcome to Ripple Trade! To activate your account, you'll need at least 20 XRP.
     ul
       li(l10n) Have another user send XRP to your Ripple name (~{{userCredentials.username}})


### PR DESCRIPTION
[Jira RT-2064](https://ripplelabs.atlassian.net/browse/RT-2064)
[Bountysource](https://www.bountysource.com/issues/3621912-blue-unfunded-banner-should-not-flash-for-a-second-before-the-user-s-balances-load)

I wasn't actually able to reproduce the issue naturally, so I had to tweak app.js to force it to happen on my machine, and worked my way to this solution based on that. So I'm hoping somebody who can reproduce this can help me out by verifying if it works or not.
