### PR TITLE
[FIX] Transaction Summary doesn't show Destination Tag (RT-1462)

### DIFF
--- a/src/jade/tabs/tx.jade
+++ b/src/jade/tabs/tx.jade
@@ -42,11 +42,18 @@ section.single.ddpage.content(ng-controller="TxCtrl", ng-switch on="state")
               span :
             dd {{transaction.Amount | rpcurrencyfull}}
         hr
-        dl.details
-          dt
-            span(l10n) Network fee paid
-            span :
-          dd {{transaction.Fee | rpamount}} XRP
+        group.clearfix
+          dl.details.half
+            dt
+              span(l10n) Network fee paid
+              span :
+            dd {{transaction.Fee | rpamount}} XRP
+          dl.details.half
+            group(ng-show="transaction.DestinationTag !== null && transaction.DestinationTag !== undefined")
+              dt
+                span(l10n) Destination tag
+                span :
+              dd {{transaction.DestinationTag}}
         hr
         dl.details
           dt


### PR DESCRIPTION
@annatonger
# /tx?id=A240D5C8F90C04071CB5C3A648E07FEF65B79D820C953C2D8C74879E0B5F6FEB

![image](https://cloud.githubusercontent.com/assets/158528/3893092/eec66398-2237-11e4-97e1-35831d045a39.png)
# /tx?id=C5A65016F56A772868168C2AD846004F318F97C3EE47676ED9B384671F7FC174

![image](https://cloud.githubusercontent.com/assets/158528/3893087/e84a0b46-2237-11e4-910f-fce836fefe41.png)

[RT-1462](https://ripplelabs.atlassian.net/browse/RT-1462) [BS](https://www.bountysource.com/issues/2842633-ripple-trade-transaction-summary-doesn-t-show-destination-tag)
