### PR TITLE
[FIX] Show ripple names on notifications

### DIFF
--- a/src/jade/client/navbar.jade
+++ b/src/jade/client/navbar.jade
@@ -49,11 +49,11 @@ nav.navbar(role="navigation", ng-controller="NavbarCtrl")
                     span(l10n) You sent
                       strong.nowrap  {{entry.transaction.amount | rpamount}} {{entry.transaction.amount | rpcurrency}}
                       |  to
-                      span.address(title="{{entry.transaction.counterparty}}")  {{entry.transaction.counterparty | rpcontactname}}
+                      span.address(title="{{entry.transaction.counterparty}}")  {{entry.transaction.counterparty | rpcontactnamefull | rpripplename: {tilde: true} }}
                     != require("../tabs/history/effects.jade")()
                   .transaction(ng-switch-when="received")
                     span.address(title="{{entry.transaction.counterparty}}", l10n)
-                      span {{entry.transaction.counterparty | rpcontactname}}
+                      span {{entry.transaction.counterparty | rpcontactnamefull | rpripplename: {tilde: true} }}
                       |  sent you
                       strong.nowrap  {{entry.transaction.amount | rpamount:{reference_date:entry.dateRaw} }} {{entry.transaction.amount | rpcurrency}}
                     != require("../tabs/history/effects.jade")()


### PR DESCRIPTION
So this is sort of a small test of the new rpRippleName directive.

I'm combining the ripple name and ripple contact directives such that:
- If a ripple name is found, use it.
- If no ripple name is found, but a contact name exists, use the contact name.
- If neither is found, use address.

I'm thinking it would be nice to have a directive which implements this logic directly? That would help performance a bit.

It's also worth making a deliberate decision regarding priority, i.e. if contact name should have precedence over ripple name or vice versa.

(Note: This was rebased off release)
