### PR TITLE
[FIX] Remove hover effect on balances dropdown

### DIFF
--- a/src/less/ripple/layout.less
+++ b/src/less/ripple/layout.less
@@ -466,14 +466,6 @@ footer {
 
   & > li {
     padding: 15px 10px;
-
-    &.balance {
-      cursor: pointer;
-    }
-
-    &:hover {
-      background: darken(@white,3%);
-    }
   }
 
   ul {


### PR DESCRIPTION
Minor fix requested by @annatonger, no jira issue that I know of.

Removes the on-hover effect from the balances dropdown in the navbar.
