### PR TITLE
[FIX] Show error msg when insufficient XRP to send

### DIFF
--- a/src/jade/tabs/send.jade
+++ b/src/jade/tabs/send.jade
@@ -189,6 +189,9 @@ section.single.content(ng-controller='SendCtrl')
         | You cannot send {{send.amount}} {{send.currency}} to
         |  {{send.recipient}}. Either your account has insufficient funds,
         |  or {{send.recipient}} doesn't accept {{send.currency}}.
+      p.literal(ng-show="send.path_status == 'no-path' && send.currency_code == 'XRP'", l10n)
+        | You cannot send {{send.amount}} {{send.currency}} to
+        |  {{send.recipient}}. Your account has insufficient funds.
       p.literal(ng-show="send.path_status == 'error-no-currency'", l10n)
         | There are no valid currency choices for this destination.
       p.literal(ng-show="send.path_status == 'error-quote'", l10n)


### PR DESCRIPTION
https://www.bountysource.com/issues/4118716-try-to-send-more-xrp-than-you-can-no-error-message
