### PR TITLE
[DOC] Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you want to watch for changes and have the client rebuild for index_debug.htm
 
 Please have a look at our ['Setting Up Local Environment' wiki post](https://github.com/ripple/ripple-client/wiki/Setting-Up-Local-Environment) for more information.
 
-Once building has completed, create a 'ripple.txt' file inside 'build/bundle/web/', you can copy the contents for the file from [here](http://rippletrade.com/ripple.txt).
+Once building has completed, create a 'ripple.txt' file inside 'build/bundle/web/', you can copy the contents for the file from [here](https://www.ripple.com/ripple.txt).
 
 ## Directory Layout
 

--- a/src/js/config-example.js
+++ b/src/js/config-example.js
@@ -7,7 +7,7 @@ var Options = {
   // Local domain
   //
   // Which domain should ripple-client consider native?
-  domain: 'ripple.com',
+  domain: 'local.ripple.com',
 
   // Rippled to connect
   server: {


### PR DESCRIPTION
Some npm packages require python 2, so the README should list it as a dependency.

Also the README should say something about ripple.txt.
