### PR TITLE
[FEATURE] Disable pw requests from popover (RT-2001)

### DIFF
--- a/src/jade/popup/unlock.jade
+++ b/src/jade/popup/unlock.jade
@@ -8,6 +8,11 @@ form(role="form", ng-submit="confirm()")
         ng-model="unlock.password", rp-focus)
     p.help-block(ng-switch on="unlock.purpose")
       span(ng-switch-when="showSecret", l10n) Please enter your password to show your secret key.
+        span.input-group.helperInput.call-to-action(ng-show="unlock.showDisablePromptCheckbox")
+          input(type="checkbox",
+            name="disablePasswordPromptCheckbox",
+            ng-model="unlock.disablePasswordPrompt")
+          label(for="disablePasswordPromptCheckbox", l10n) Remember my password until I refresh or log out.
       span(ng-switch-default, l10n) Please enter your password to confirm this transaction.
     .alert.alert-danger(ng-show="unlock.error == 'password'", l10n) This password is incorrect, please try again.
     p.literal(ng-show="unlock.isConfirming", rp-spinner="4", l10n) Confirming password

--- a/src/jade/tabs/security.jade
+++ b/src/jade/tabs/security.jade
@@ -1,4 +1,12 @@
 section.col-xs-12.content(ng-controller="SecurityCtrl")
+  .col-xs-12(ng-show="showPasswordDisabledAnnouncement")
+    div.auth-success.banner
+      br
+      p.text-center(l10n)
+        | You have successfully turned off password requests.
+        |  You will still need to enter your password after each page refresh.
+      a.dismiss(href="", id="hide", ng-click="showPasswordDisabledAnnouncement = false", l10n) hide
+      br
   .col-xs-12(ng-hide="isUnlocked")
     .auth-attention.sessionUnlock
       h5(l10n) Active Session Timeout

--- a/src/js/tabs/security.js
+++ b/src/js/tabs/security.js
@@ -36,6 +36,8 @@ SecurityTab.prototype.angular = function (module) {
     $scope.errorLoading2FA = false;
     $scope.requirePasswordChanged = false;
     
+    $scope.showPasswordDisabledAnnouncement = false;
+
     $scope.$on('$blobUpdate', onBlobUpdate);
     onBlobUpdate();
 
@@ -96,12 +98,13 @@ SecurityTab.prototype.angular = function (module) {
 
 
     $scope.unmaskSecret = function () {
-      keychain.requestSecret($id.account, $id.username, 'showSecret', function (err, secret) {
+      keychain.requestSecret($id.account, $id.username, 'showSecret', function (err, secret, showAnnouncement) {
         if (err) {
           // XXX Handle error
           return;
         }
 
+        $scope.showPasswordDisabledAnnouncement = showAnnouncement;
         $scope.security.master_seed = secret;
       });
     };

--- a/src/less/ripple/content.less
+++ b/src/less/ripple/content.less
@@ -381,18 +381,26 @@ a.danger {
   font-size: 18px;
 }
 
-.auth-attention {
+.auth-base(@background, @color) {
   margin-bottom: 20px;
   font-size: 13px;
-  background: @lightblue;
-  color: @darkblue;
-  border: 1px solid @midgray;
   padding: 15px ;
   .rounded(5px);
+  border: 1px solid @midgray;
+  background: @background;
+  color: @color;
 
   span {
     font-family: OpenSansBold;
   }
+}
+
+.auth-attention {
+  .auth-base(@lightblue, @darkblue);
+}
+
+.auth-success {
+  .auth-base(@lightgreen, @darkgreen);
 }
 
 .blank {


### PR DESCRIPTION
Adds a checkbox to the unlock popup, allowing the user to disable password prompts directly from the popup.

[Bountysource](https://www.bountysource.com/issues/3432909-ripple-trade-add-option-to-disable-password-requests-to-the-bottom-of-the-unlock-account-popover)
[Jira RT-2001](https://ripplelabs.atlassian.net/browse/RT-2001)

See it in action in the gif below.
![http://g.recordit.co/dXytODUOie.gif](http://g.recordit.co/dXytODUOie.gif)
(The gif has an incorrect text next to the checkbox, it's actually `Remember my password until I refresh or log out.`)

Side-note: As can be seen in the gif, it seems like there is an issue with the spinner not being centered. I'm pretty sure it's not an issue introduced in these changes, but if I get some spare time I will try to see if I can find a fix, and if I do I will put it in a new pull request.
