### PR TITLE
[FIX] Path finding stopped working with gateway account (RT-2218, RT-2215)

### DIFF
--- a/src/js/controllers/app.js
+++ b/src/js/controllers/app.js
@@ -707,18 +707,47 @@ module.controller('AppCtrl', ['$rootScope', '$compile', 'rpId', 'rpNetwork',
       var currency = balances[currency_name];
       var currency_hex = currency.total.currency().to_hex();
       var result = [];
+      var issuer = false;
       for (var issuer_name in currency.components)
       {
         if (!currency.components.hasOwnProperty(issuer_name)) continue;
-        result.push({ currency: currency_hex, issuer: issuer_name});
+        var component = currency.components[issuer_name];
+        if (component.is_negative())
+          issuer = true;
+
+        if (component.is_positive())
+          result.push({ currency: currency_hex, issuer: issuer_name});
       }
 
-      if (result.length > 1)
-        src_currencies.push({ currency: currency_hex });
+      if (result.length > 1 || issuer)
+        result.unshift({ currency: currency_hex });
 
       src_currencies = src_currencies.concat(result);
     }
     return src_currencies;
+  };
+
+  $scope.generate_issuer_currencies = function () {
+    var balances = $scope.balances;
+    var isIssuer = [];
+    for (var currency_name in balances) {
+      if (!balances.hasOwnProperty(currency_name)) continue;
+
+      var currency = balances[currency_name];
+      var currency_hex = currency.total.currency().to_hex();
+      isIssuer[currency_hex] = false;
+      for (var issuer_name in currency.components)
+      {
+        if (!currency.components.hasOwnProperty(issuer_name)) continue;
+        var component = currency.components[issuer_name];
+        if (component.is_negative())
+        {
+          isIssuer[currency_hex] = true;
+          break;
+        }
+      }
+    }
+    return isIssuer;
   };
 
   /**

--- a/src/js/tabs/exchange.js
+++ b/src/js/tabs/exchange.js
@@ -50,7 +50,9 @@ ExchangeTab.prototype.angular = function (module)
         var currency = Currency.from_human($scope.exchange.currency_name ? $scope.exchange.currency_name : "XRP");
         exchange.currency_obj = currency;
         exchange.currency_code = currency.get_iso();
-        exchange.currency_name = currency.to_human({full_name:$scope.currencies_all_keyed[currency.get_iso()].name});
+        exchange.currency_name = currency.to_human({
+          full_name: $scope.currencies_all_keyed[currency.get_iso()] ? $scope.currencies_all_keyed[currency.get_iso()].name : null
+        });
         $scope.update_exchange();
       }, true);
 
@@ -126,6 +128,7 @@ ExchangeTab.prototype.angular = function (module)
               $id.account,
               amount,
               $scope.generate_src_currencies());
+          var isIssuer = $scope.generate_issuer_currencies();
 
           var lastUpdate;
 
@@ -156,7 +159,7 @@ ExchangeTab.prototype.angular = function (module)
                       ? raw.paths_computed
                       : raw.paths_canonical;
 
-                  if (alt.amount.issuer().to_json() != $scope.address) {
+                  if (alt.amount.issuer().to_json() != $scope.address && !isIssuer[alt.amount.currency().to_hex()]) {
                     currencies[alt.amount.currency().to_hex()] = true
                   }
 


### PR DESCRIPTION
- Specifying every currency/issuer pairs with positive amounts only while
  doing path-finding.
- Allow issue currency when the currency has both positive and negative
  components.
- Fix path displayed as n/a.
  (related to "Selected currency should be the first option")
- Fix a bug when exchanging currencies without full names.

[RT-2218](https://ripplelabs.atlassian.net/browse/RT-2218)
[RT-2215](https://ripplelabs.atlassian.net/browse/RT-2215)
