### PR TITLE
[FIX] "bower:install" (bower) task no longer fails during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "json-loader": "~0.5.0",
     "node-po": "~0.1.2",
     "grunt-jade-l10n-extractor": "~0.1.2",
-    "grunt-bower-task": "~0.3.4",
+    "grunt-bower-task": "~0.4.0",
     "grunt-webfont": "~0.3.4",
     "grunt-shell": "~0.6.4",
     "grunt-contrib-connect": "~0.5.0",


### PR DESCRIPTION
i was getting build errors because of grunt-bower-task being at 0.3.4 -- updating to current version 0.4.0 lets me get through a grunt build.  not sure if this is a problem for anyone else or a factor of my personal environment.  i'm on os x yosemite beta 10.10
