### PR TITLE
[FIX] Show error msg when insufficient XRP to send

### DIFF
--- a/src/jade/tabs/send.jade
+++ b/src/jade/tabs/send.jade
@@ -189,7 +189,7 @@ section.single.content(ng-controller='SendCtrl')
         | You cannot send {{send.amount}} {{send.currency}} to
         |  {{send.recipient}}. Either your account has insufficient funds,
         |  or {{send.recipient}} doesn't accept {{send.currency}}.
-      p.literal(ng-show="send.path_status == 'no-path' && send.currency_code == 'XRP'", l10n)
+      p.literal(ng-show="send.path_status == 'no-path' && send.currency_code == 'XRP' && send.sender_insufficient_xrp", l10n)
         | You cannot send {{send.amount}} {{send.currency}} to
         |  {{send.recipient}}. Your account has insufficient funds.
       p.literal(ng-show="send.path_status == 'error-no-currency'", l10n)


### PR DESCRIPTION
Do not show the error message when the user has sufficient XRP funds,
but no alternative paths.
