### PR TITLE
[FIX] Don't show BTC addr. on cancel

### DIFF
--- a/src/jade/tabs/btc.jade
+++ b/src/jade/tabs/btc.jade
@@ -34,34 +34,37 @@ section.col-xs-12.content(ng-controller='BtcCtrl')
                 target="_blank", l10n) Remove Limit
             div(ng-hide="loadState.B2RInstructions") Loading...
           .inactive(ng-hide="B2R.active")
-            label(l10n) To deposit, generate a bitcoin receiving address
-              |  using the&#32;
-              a(href="https://btc2ripple.com", target="_blank") btc2ripple
-              |  service powered by SnapSwap.
-            .row.action
-              .col-xs-12.col-sm-6.col-md-4
-                rp-popup
-                  a.btn.btn-success.btn-sm.btn-block.sign(href="", rp-popup-link,
-                    ng-click="openPopup()", l10n) Generate bitcoin address
-                  div.connectModal(rp-popup-content)
-                    .modal-header
-                      .navbar-brand.hidden-sm.modal-logo#logo
-                      .modal-title(l10n) Connect
-                    .modal-body
-                      div.modal-prompt(l10n) btc2ripple would like to:
-                      div.grey-focus
-                        div.modal-permissions(l10n) - Receive your email address
-                          span.modal-email(l10n) ({{userBlob.data.email}})
-                        div.modal-permissions(l10n) - Hold deposited BTC on your behalf
-                      div.modal-agreement(l10n) By proceeding, you agree to the btc2ripple
-                        a(href="https://btc2ripple.com/#/terms/of/service", target="_blank")  terms of service.
-                      div.modal-buttons
-                        button.modal-btn.btn.btn-default.btn-success.btn-md(ng-click="B2RSignup()",
-                          rp-spinner='{{loading ? 4 : null}}', ng-disabled="loading")
-                          span(ng-show="loading", l10n) Loading...
-                          span(ng-hide="loading", l10n) Confirm
-                        button.modal-btn.btn.btn-default.btn-link.btn-md(data-dismiss="modal"
-                          ng-hide="loading", l10n) cancel
-                      span.modal-error(ng-show="emailError", l10n)
-                        | SnapSwap's btc2ripple service is currently unavailable.
-                        |  Please check back later.
+            span(ng-show="loading")
+              label(l10n) Waiting for response from SnapSwap service...
+            span(ng-hide="loading")
+              label(l10n) To deposit, generate a bitcoin receiving address
+                |  using the&#32;
+                a(href="https://btc2ripple.com", target="_blank") btc2ripple
+                |  service powered by SnapSwap.
+              .row.action
+                .col-xs-12.col-sm-6.col-md-4
+                  rp-popup
+                    a.btn.btn-success.btn-sm.btn-block.sign(href="", rp-popup-link,
+                      ng-click="openPopup()", l10n) Generate bitcoin address
+                    div.connectModal(rp-popup-content)
+                      .modal-header
+                        .navbar-brand.hidden-sm.modal-logo#logo
+                        .modal-title(l10n) Connect
+                      .modal-body
+                        div.modal-prompt(l10n) btc2ripple would like to:
+                        div.grey-focus
+                          div.modal-permissions(l10n) - Receive your email address
+                            span.modal-email(l10n) ({{userBlob.data.email}})
+                          div.modal-permissions(l10n) - Hold deposited BTC on your behalf
+                        div.modal-agreement(l10n) By proceeding, you agree to the btc2ripple
+                          a(href="https://btc2ripple.com/#/terms/of/service", target="_blank")  terms of service.
+                        div.modal-buttons
+                          button.modal-btn.btn.btn-default.btn-success.btn-md(ng-click="B2RSignup()",
+                            rp-spinner='{{loading ? 4 : null}}', ng-disabled="loading")
+                            span(ng-show="loading", l10n) Loading...
+                            span(ng-hide="loading", l10n) Confirm
+                          button.modal-btn.btn.btn-default.btn-link.btn-md(data-dismiss="modal"
+                            ng-hide="loading", l10n) cancel
+                        span.modal-error(ng-show="emailError", l10n)
+                          | SnapSwap's btc2ripple service is currently unavailable.
+                          |  Please check back later.


### PR DESCRIPTION
[Jira RT-2196](https://ripplelabs.atlassian.net/browse/RT-2196)
[Bountysource](https://www.bountysource.com/issues/4270014-bitcoin-fund-flow-do-not-show-generated-btc-address-if-user-does-not-submit-password)

[![gif](http://g.recordit.co/3muBMnt9p8.gif)](http://recordit.co/3muBMnt9p8)
