### PR TITLE
[FIX] Balance overview: Align summary baselines

### DIFF
--- a/src/less/ripple/tabs.less
+++ b/src/less/ripple/tabs.less
@@ -675,7 +675,6 @@
           display: block;
           color: @black;
           text-decoration: none;
-          line-height: 60px;
         }
       }
     }


### PR DESCRIPTION
In the Balance overview, the currency value (second column) was not on
the same baseline as the logo/currency (first column). This was due to
a different line-height for the first column.
