### PR TITLE
[FIX] Interface: Enhance readability of grey text

### DIFF
--- a/src/less/ripple/combobox.less
+++ b/src/less/ripple/combobox.less
@@ -36,7 +36,7 @@
 
       .additional {
         display: block;
-        color: @midgray;
+        color: @darkgray;
         font-size: 12px;
       }
     }

--- a/src/less/ripple/content.less
+++ b/src/less/ripple/content.less
@@ -35,7 +35,7 @@ h1 {
 
 .steps {
   font-size: 12px;
-  color: @midgray;
+  color: @darkgray;
 
   .selected {
     color: @black;

--- a/src/less/ripple/layout.less
+++ b/src/less/ripple/layout.less
@@ -104,14 +104,13 @@ header {
       }
 
       > li {
-        margin-left: 5px;
-        margin-right: 5px;
+        margin-left: 1px;
 
         > a {
           color: @white;
           .transition-duration(0.1s);
           cursor: pointer;
-          padding: 15px 10px;
+          padding: 15px;
 
           .caret {
             border-top-color: @white;
@@ -120,9 +119,8 @@ header {
 
           &:hover,
           &:focus {
-            color: @midgray;
             text-decoration: none;
-            background-color: transparent;
+            background: lighten(@midblue,3%);
           }
         }
 
@@ -205,14 +203,15 @@ header {
 
           &:hover,
           &:focus {
-            color: @midgray;
+            color: @black;
             text-decoration: none;
+            border-bottom: 2px solid @midgray;
           }
         }
 
-        &.active {
+        &.active a {
           font-family: 'OpenSansRegular';
-          border-bottom: 2px solid @midgray;
+          border-bottom: 2px solid @darkgray;
         }
       }
     }

--- a/src/less/ripple/status.less
+++ b/src/less/ripple/status.less
@@ -179,7 +179,7 @@
     }
 
     &.type-offline {
-      color: @midgray;
+      color: @darkgray;
       background-color: @black;
       border-color: @notification-border;
     }

--- a/src/less/ripple/tabs.less
+++ b/src/less/ripple/tabs.less
@@ -536,7 +536,7 @@
         font-family : OpenSansBold;
 
         .desc {
-          color: @midgray;
+          color: @darkgray;
           font: 12px OpenSansLight;
         }
       }
@@ -579,7 +579,7 @@
 
         .lbl {
           font-size: 12px;
-          color: @midgray;
+          color: @darkgray;
           font: 12px OpenSansLight;
         }
 
@@ -1535,7 +1535,7 @@
         }
 
         .ex {
-           color: @midgray;
+           color: @darkgray;
 
            .pair {
              margin-left: 5px;
@@ -2203,7 +2203,7 @@
       margin-bottom: 10px;
 
       .currency {
-        color: @midgray;
+        color: @darkgray;
       }
     }
 
@@ -2262,7 +2262,7 @@
 
     .issuer {
       font-size: 10px;
-      color: @midgray;
+      color: @darkgray;
     }
   }
 
@@ -2351,7 +2351,7 @@ html.t-trade header nav ul > li.active#nav-advanced > a:after {
     font-family : OpenSansBold;
 
     .desc {
-      color: @midgray;
+      color: @darkgray;
       font: 12px OpenSansLight;
     }
   }


### PR DESCRIPTION
RT­2243 #Deliver
In multiple places of the interface, #ccccca @midgray is used as text
color. This is hard to read, especially on lightgray backgrounds.
Replace color: @midgray with @darkgray where suitable, enhance navbar
and subnav hover styles.
