### PR TITLE
[FIX] Improve navbar menu items clickability

### DIFF
--- a/src/less/ripple/tabs.less
+++ b/src/less/ripple/tabs.less
@@ -2305,8 +2305,17 @@ header nav.navbar .open > .dropdown-menu {
   background-color: @lightgray;
 }
 
-.dropdown-menu > li > a {
-  color: @midblue;
+.dropdown-menu  {
+  padding: 0;
+
+  > li > a {
+    color: @midblue;
+    padding: 12px 20px;
+  }
+
+  .divider {
+    margin: 0;
+  }
 }
 
 html.t-trade header nav ul > li.active#nav-advanced > a:after {


### PR DESCRIPTION
In the top-right navbar menu, there are dividers between the menu items.
These dividers are not clickable, so not the entire menu height splits
into clickable items. Convert the dividers into menu item padding with
borders to enhance accessibility.
