### PR TITLE
[FIX] Send: Add spacing for destination tag hider

### DIFF
--- a/src/jade/tabs/send.jade
+++ b/src/jade/tabs/send.jade
@@ -70,9 +70,7 @@ section.col-xs-12.content(ng-controller='SendCtrl')
     .row.form-group(ng-show='send.show_dt_field')
       .col-xs-12.col-sm-8.col-md-6
         label(for='send_dt', l10n) Destination tag
-        |
-        a(href="", ng-click="send.show_dt_field = false", l10n)
-          | hide
+        a(href="", ng-click="send.show_dt_field = false", l10n) hide
         input.form-control#send_dt(
         name='send_dt', type='text'
         ng-model='send.dt'

--- a/src/less/ripple/tabs.less
+++ b/src/less/ripple/tabs.less
@@ -1448,6 +1448,10 @@
       padding: 0;
       list-style-type: none;
     }
+
+    label[for=send_dt] {
+      margin-right: 20px;
+    }
   }
 
   .mode-status {


### PR DESCRIPTION
On the Send tab, the Destination tag has a hide-link behind. Instead of
separating it with a pipe, use spacing instead.
