### PR TITLE
[FIX] L10n: Switch to English language properly

### DIFF
--- a/src/js/entry/desktop.js
+++ b/src/js/entry/desktop.js
@@ -144,8 +144,6 @@ app.config(['$routeProvider', function ($routeProvider) {
     redirectTo: function(routeParams, path, search){
       lang = routeParams.language;
 
-      if (lang == 'en') lang = '';
-
       if (!store.disabled) {
         store.set('ripple_language',lang ? lang : '');
       }

--- a/src/js/entry/web.js
+++ b/src/js/entry/web.js
@@ -153,8 +153,6 @@ app.config(['$routeProvider', '$injector', function ($routeProvider, $injector) 
     redirectTo: function(routeParams, path, search){
       lang = routeParams.language;
 
-      if (lang == 'en') lang = '';
-
       if (!store.disabled) {
         store.set('ripple_language',lang ? lang : '');
       }


### PR DESCRIPTION
When switching to English, the stored language was actually reset to
blank instead. For browsers that don't use English as default language,
this causes the user's language preference to load instead of English.
When the user wants to switch to English, it should be done.
