### PR TITLE
[FIX] L10n: Make SSN string not localizable

### DIFF
--- a/l10n/templates/messages.pot
+++ b/l10n/templates/messages.pot
@@ -1524,10 +1524,6 @@ msgstr "Day{{1}}"
 msgid "Year{{1}}"
 msgstr "Year{{1}}"
 
-#: src/jade/tabs/kyc.jade:94
-msgid "Last 4 digits of Social Security Number"
-msgstr "Last 4 digits of Social Security Number"
-
 #: src/jade/tabs/kyc.jade:102
 msgid "Continue to identity questions"
 msgstr "Continue to identity questions"

--- a/src/jade/tabs/kyc.jade
+++ b/src/jade/tabs/kyc.jade
@@ -119,7 +119,8 @@ section.col-xs-12.content(ng-controller='KycCtrl')
                   required)
             .row
               .col-xs-12.col-sm-6.col-md-6
-                div(l10n) Last 4 digits of Social Security Number
+                //- Don't make the following localizable, see RT-1539
+                div Last 4 digits of Social Security Number
             .row
               .col-xs-12.col-sm-6.col-md-2
                 div.ssn-hidden &#149;&#149;&#149; - &#149;&#149; -


### PR DESCRIPTION
The kyc string "Last 4 digits of Social Security Number" is U.S. only.
