### PR TITLE
[FEATURE] RT-2437 Kyc tab: Add "US-only" banner

### DIFF
--- a/src/jade/tabs/kyc.jade
+++ b/src/jade/tabs/kyc.jade
@@ -10,9 +10,9 @@ section.col-xs-12.content(ng-controller='KycCtrl')
   div(ng-show="'web' === client && !loadingAccount && !account.Balance && loadState.account && connected")
     include banner/unfunded
 
-  div.auth-attention.banner(ng-hide="showUsOnlyBanner")
+  div.auth-attention.banner(ng-hide="hideUsOnlyBanner")
     h4#announcement(l10n) Profile completion is only available to US residents.
-    a.dismiss(href="", id="hide", ng-click="showUsOnlyBanner=!showUsOnlyBanner")  ×
+    a.dismiss(href="", id="hide", ng-click="hideUsOnlyBanner=!hideUsOnlyBanner")  ×
     br
 
   group.mode-granted.wide(ng-show='notif !== "clear"')


### PR DESCRIPTION
Add banner "Profile completion is only available to US residents."
to kyc wizard page top.
