### PR TITLE
[TASK] Run devserver with elevated permissions on Mac

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -156,7 +156,9 @@ module.exports = function(grunt) {
         failOnError: true
       },
       startdevserver: {
-        command: 'node ./scripts/web-server.js'
+        command: 
+          process.platform === 'darwin' ? 'sudo node ./scripts/web-server.js'
+                                        : 'node ./scripts/web-server.js'
       },
       removeFiles: {
         command: [


### PR DESCRIPTION
Apparently the devserver needs to be run with elevated permissions on os x, possibly on linux as well.

I assume it would work to run the grunt task with sudo, but I offer this as an alternative. I'm not sure what is preferable on a Mac - this, or indicating in the documentation that the task should be run with elevated permissions.
