### PR TITLE
[Fix] RT-2544 'hide' button behavior in 'My Orders' in trade tab

### DIFF
--- a/src/jade/tabs/trade.jade
+++ b/src/jade/tabs/trade.jade
@@ -390,7 +390,7 @@ section.col-xs-12.content(ng-controller="TradeCtrl")
           h3(l10n) My Orders
             span &#32;({{offersCount}})
             small.toggle(ng-hide="isEmpty(offers)", ng-click="hideOffers = !hideOffers") {{hideOffers ? "show" : "hide"}}
-          .listings.offers(ng-class="{show : !hideOffers}")
+          .listings.offers(ng-hide="hideOffers")
             .my
               div(ng-hide="isEmpty(offers)")
                 .row.head.hidden-xs


### PR DESCRIPTION
Originally, both "My Orders" and "Orderbook" used ng-class, see
https://github.com/ripple/ripple-client/commit/139dac6859d40a22161b5a3edba68fc606d23478#diff-a5dc867b23059f00c00a1db4419375a3

Then later on @vhpoet switched the one in "Orderbook" to ng-hide
https://github.com/ripple/ripple-client/commit/429b0f3f0c0d3de0e84384567f91fc4946f1a85b#diff-a5dc867b23059f00c00a1db4419375a3
