### PR TITLE
[FEATURE] Trust: Disable Remove on incoming trust (RT-1878)

### DIFF
--- a/src/jade/tabs/trust.jade
+++ b/src/jade/tabs/trust.jade
@@ -320,14 +320,14 @@ section.col-xs-12.content(ng-controller="TrustCtrl")
                             cancel-button-css="btn btn-cancel"
                             cancel-button-text="cancel"
                             ng-hide="showPassword==true")
-                              button.btn.btn-block.btn-danger.submit(type="button", ng-click="load_orderbook()", ng-show="component.limit._value.t !== 0", l10n) Remove
+                              button.btn.btn-block.btn-danger.submit(type="button", ng-click="load_orderbook()", ng-show="!isIncoming()", l10n) Remove
                               span(
                                 rp-popover
                                 rp-popover-placement="bottom"
                                 rp-popover-trigger="hover"
                                 l10n-rp-popover-title="Incoming trust"
                                 l10n-data-content="You can't delete incoming trust lines. Incoming trust lines are when other Ripple users trust you.")
-                                button.btn.btn-block.btn-danger.submit(type="button", ng-click="load_orderbook()", ng-show="component.limit._value.t === 0", disabled, l10n) Remove
+                                button.btn.btn-block.btn-danger.submit(type="button", ng-click="load_orderbook()", ng-show="isIncoming()", disabled, l10n) Remove
                           span(ng-show='trust.balance !== "0" && orderbookStatus === "not"')
                             rp-confirm(
                             action-text="Are you sure you want to remove this gateway? Ripple Trade will return the balance of {{ trust.balance }} {{ trust.currency }} to the issuer. This action can't be undone."
@@ -337,7 +337,7 @@ section.col-xs-12.content(ng-controller="TrustCtrl")
                             cancel-button-css="btn btn-cancel"
                             cancel-button-text="cancel"
                             ng-hide="showPassword==true")
-                              button.btn.btn-block.btn-danger.submit(type="button", ng-click="load_orderbook()", ng-show="component.limit._value.t !== 0", l10n) Remove
+                              button.btn.btn-block.btn-danger.submit(type="button", ng-click="load_orderbook()", ng-show="!isIncoming()", l10n) Remove
                               span(
                                 rp-popover
                                 rp-popover-placement="bottom"
@@ -346,14 +346,14 @@ section.col-xs-12.content(ng-controller="TrustCtrl")
                                 l10n-data-content="You can't delete incoming trust lines. Incoming trust lines are when other Ripple users trust you.")
                                 button.btn.btn-block.btn-danger.submit(type="button", ng-click="load_orderbook()", ng-show="component.limit._value.t === 0", disabled, l10n) Remove
                           span(ng-show='trust.balance === "0"')
-                            button.btn.btn-block.btn-danger.submit(type="button", ng-click="delete_account()", ng-show="component.limit._value.t !== 0", l10n) Remove
+                            button.btn.btn-block.btn-danger.submit(type="button", ng-click="delete_account()", ng-show="!isIncoming()", l10n) Remove
                             span(
                               rp-popover
                               rp-popover-placement="bottom"
                               rp-popover-trigger="hover"
                               l10n-rp-popover-title="Incoming trust"
                               l10n-data-content="You can't delete incoming trust lines. Incoming trust lines are when other Ripple users trust you.")
-                              button.btn.btn-block.btn-danger.submit(type="button", ng-click="delete_account()", ng-show="component.limit._value.t === 0", disabled, l10n) Remove
+                              button.btn.btn-block.btn-danger.submit(type="button", ng-click="delete_account()", ng-show="isIncoming()", disabled, l10n) Remove
                         .col-md-5.col-sm-5.col-xs-6
                           a.btn.btn-block.btn-cancel(href="", ng-click="cancel()"
                           ng-disabled="trust.loading", l10n) cancel
@@ -397,14 +397,14 @@ section.col-xs-12.content(ng-controller="TrustCtrl")
                               cancel-button-css="btn btn-cancel"
                               cancel-button-text="cancel"
                               ng-hide="showPassword==true")
-                                button.btn.btn-block.btn-danger.btn-xs.submit(type="button", ng-click="load_orderbook()", ng-show="component.limit._value.t !== 0", l10n) Remove
+                                button.btn.btn-block.btn-danger.btn-xs.submit(type="button", ng-click="load_orderbook()", ng-show="!isIncoming()", l10n) Remove
                                 span(
                                   rp-popover
                                   rp-popover-placement="bottom"
                                   rp-popover-trigger="hover"
                                   l10n-rp-popover-title="Incoming trust"
                                   l10n-data-content="You can't delete incoming trust lines. Incoming trust lines are when other Ripple users trust you.")
-                                  button.btn.btn-block.btn-danger.btn-xs.submit(type="button", ng-click="load_orderbook()", ng-show="component.limit._value.t === 0", disabled, l10n) Remove
+                                  button.btn.btn-block.btn-danger.btn-xs.submit(type="button", ng-click="load_orderbook()", ng-show="isIncoming()", disabled, l10n) Remove
                             .col-xs-12(ng-show='trust.balance !== "0" && orderbookStatus === "not"')
                               rp-confirm(
                               action-text="Are you sure you want to remove this gateway? Ripple Trade will return the balance of {{ trust.balance }} {{ trust.currency }} to the issuer. This action can't be undone."
@@ -414,24 +414,23 @@ section.col-xs-12.content(ng-controller="TrustCtrl")
                               cancel-button-css="btn btn-link"
                               cancel-button-text="cancel"
                               ng-hide="showPassword==true")
-                                button.btn.btn-block.btn-danger.btn-xs.submit(type="button", ng-click="load_orderbook()", ng-show="component.limit._value.t !== 0", l10n) Remove
+                                button.btn.btn-block.btn-danger.btn-xs.submit(type="button", ng-click="load_orderbook()", ng-show="!isIncoming()", l10n) Remove
                                 span(
                                   rp-popover
                                   rp-popover-placement="bottom"
                                   rp-popover-trigger="hover"
                                   l10n-rp-popover-title="Incoming trust"
                                   l10n-data-content="You can't delete incoming trust lines. Incoming trust lines are when other Ripple users trust you.")
-                                  button.btn.btn-block.btn-danger.btn-xs.submit(type="button", ng-click="load_orderbook()", ng-show="component.limit._value.t === 0", disabled, l10n) Remove
+                                  button.btn.btn-block.btn-danger.btn-xs.submit(type="button", ng-click="load_orderbook()", ng-show="isIncoming()", disabled, l10n) Remove
                             .col-xs-12(ng-show='trust.balance === "0"')
-                              button.btn.btn-block.btn-danger.btn-xs.submit(type="button", ng-click="delete_account()", ng-show="component.limit._value.t !== 0", l10n) Remove
+                              button.btn.btn-block.btn-danger.btn-xs.submit(type="button", ng-click="delete_account()", ng-show="!isIncoming()", l10n) Remove
                               span(
                                 rp-popover
                                 rp-popover-placement="bottom"
                                 rp-popover-trigger="hover"
                                 l10n-rp-popover-title="Incoming trust"
                                 l10n-data-content="You can't delete incoming trust lines. Incoming trust lines are when other Ripple users trust you.")
-                                button.btn.btn-block.btn-danger.btn-xs.submit(type="button", ng-click="delete_account()", ng-show="component.limit._value.t === 0", disabled, l10n) Remove
+                                button.btn.btn-block.btn-danger.btn-xs.submit(type="button", ng-click="delete_account()", ng-show="isIncoming()", disabled, l10n) Remove
                         .col-xs-3
                           a.btn.btn-block.btn-cancel(href="", ng-click="cancel()"
                             ng-disabled="trust.loading", l10n) cancel
-

--- a/src/js/tabs/trust.js
+++ b/src/js/tabs/trust.js
@@ -627,6 +627,10 @@ TrustTab.prototype.angular = function (module)
         });
       };
 
+      $scope.isIncoming = function () {
+        return $scope.component.limit._value.t === 0;
+      };
+
     }]);
 
 };


### PR DESCRIPTION
There is no point on trying to delete an incoming trust, so disable
its button and notify the user with a tooltip.
