### PR TITLE
[FEATURE] Trust: Hide edit on incoming (RT-2584)

### DIFF
--- a/src/jade/tabs/trust.jade
+++ b/src/jade/tabs/trust.jade
@@ -316,8 +316,16 @@ section.col-xs-12.content(ng-controller="TrustCtrl")
                   div(ng-show="component.no_ripple", l10n) Off
                   div(ng-hide="component.no_ripple", l10n) On
                 div(ng-hide="component.freeze_peer", ng-class="{ 'col-xs-2': advanced_feature_switch, 'col-xs-4 col-md-3': !advanced_feature_switch }")
-                  a(href="", ng-hide="editing || component.limit._value.t === 0", ng-click="edit_account()"
+                  a(href="", ng-hide="editing || isIncoming()", ng-click="edit_account()"
                     l10n) edit
+                  span(
+                    ng-show="isIncoming()"
+                    rp-popover
+                    rp-popover-placement="bottom"
+                    rp-popover-trigger="hover"
+                    l10n-rp-popover-title="Incoming trust"
+                    l10n-data-content="You can't edit incoming trust lines. Incoming trust lines are when other Ripple users trust you.")
+                    a.disabled(href="", l10n) edit
                   span(ng-show="editing && !advanced_feature_switch")
                     span(ng-hide="trust.loading")
                       div.row.row-padding-small

--- a/src/less/ripple/tabs.less
+++ b/src/less/ripple/tabs.less
@@ -942,6 +942,14 @@
     }
   }
 
+  a.disabled {
+    color: @gray-light;
+
+    &:hover, &:focus {
+      text-decoration: none;
+    }
+  }
+
   .currencyBox {
     margin: 0 0 30px;
   }


### PR DESCRIPTION
When advanced options are off, all what a user sees when clicking the
edit link on an incoming trust, is a useless Remove button.
Hide the edit link entirely for incoming trusts when advanced = off.
