### PR TITLE
[FIX] Trade URI: Actually save the issuer parameters & allow resolve Ripple name

### DIFF
--- a/src/js/tabs/trade.js
+++ b/src/js/tabs/trade.js
@@ -165,7 +165,7 @@ TradeTab.prototype.angular = function(module)
     };
 
     /**
-     * Happens when user cliens the currency in "My Orders".
+     * Happens when user clicks the currency in "My Orders".
      */
     $scope.goto_order_currency = function()
     {
@@ -832,6 +832,13 @@ TradeTab.prototype.angular = function(module)
         if (routeIssuers[prefix]) {
           if (ripple.UInt160.is_valid(routeIssuers[prefix][1])) {
             $scope.order[prefix + '_issuer'] = routeIssuers[prefix][1];
+          } else if (webutil.isRippleName(routeIssuers[prefix][1])) {
+            ripple.AuthInfo.get(Options.domain, routeIssuers[prefix][1], function(err, response) {
+              $scope.order[prefix + '_issuer'] = response.address;
+            });
+            // or, with this resolving method: fallback to default gateway if
+            // ripple name is not in contact.
+            //$scope.order[prefix + '_issuer'] = webutil.resolveContact($scope.userBlob.data.contacts, $scope.order[prefix + '_issuer']);
           } else {
             $location.path('/trade');
           }
@@ -840,6 +847,7 @@ TradeTab.prototype.angular = function(module)
 
       if (routeCurrencies.first && routeCurrencies.second) {
         if (routeCurrencies.first[1] !== routeCurrencies.second[1]) {
+          currencyPairChangedByNonUser = true;
           $scope.order.currency_pair = routeCurrencies.first[1] + '/' + routeCurrencies.second[1];
         } else {
           $location.path('/trade');


### PR DESCRIPTION
More specifically, this fixes the following bug:

> When I click on this link, it doesn't load the right orderbook for me- for me it
> loads the SnapSwap USD/XRP orderbook.
> 
> https://staging.ripple.com/client/#/trade?type=buy&first=USD:~Bitstamp&second=XRP&amount=0.0001&price=0.0027&max=0.1
> 
> I then tried to put Bitstamp's Ripple address in instead of the Ripple name, and
> it didn't work either. It still loaded the SnapSwap USD/XRP orderbook.
> 
> https://staging.ripple.com/client/#/trade?type=buy&first=USD: rvYAfWj5gh67oV6fW32ZzP3Aw4Eubs59B&second=XRP&amount=0.0001&price=0.0027&max=0.1
