### PR TITLE
[FIX] Transaction details displaying wrong value sent (RT-2646)

### DIFF
--- a/src/js/util/jsonrewriter.js
+++ b/src/js/util/jsonrewriter.js
@@ -150,6 +150,7 @@ var JsonRewriter = module.exports = {
   getAmountSent: function (tx, meta) {
     var sender = tx.Account;
     var difference = null;
+    var tmpDifference;
     var cur = null;
     var i;
     var affectedNode;
@@ -174,10 +175,10 @@ var JsonRewriter = module.exports = {
               affectedNode.ModifiedNode.FinalFields.Balance.currency === tx.SendMax.currency) {
 
               // Calculate the difference before/after. If HighLimit.issuer == [sender's account] negate it.
-              difference = affectedNode.ModifiedNode.PreviousFields.Balance.value - affectedNode.ModifiedNode.FinalFields.Balance.value;
-              if (affectedNode.ModifiedNode.FinalFields.HighLimit.issuer === sender) difference *= -1;
+              tmpDifference = affectedNode.ModifiedNode.PreviousFields.Balance.value - affectedNode.ModifiedNode.FinalFields.Balance.value;
+              if (affectedNode.ModifiedNode.FinalFields.HighLimit.issuer === sender) tmpDifference *= -1;
+              difference += tmpDifference;
               cur = affectedNode.ModifiedNode.FinalFields.Balance.currency;
-              break;
             }
           }
         }


### PR DESCRIPTION
As a result, this pull request also fixed a similar bug in the history tab. For example(Transaction #E79AC11430A02DCB3383C8B36BF0481E52212737C511DCD17FCE44BC65700B8D):
![ripple-history-bug](https://cloud.githubusercontent.com/assets/1846668/5151887/cb7ea8c2-721f-11e4-879c-b25aceb2f9eb.png)

It is easy to guess why the bug exists from the bug in the history tab.
