### PR TITLE
[TASK] settings: Remove the need for some of the browser force reload

### DIFF
--- a/src/js/tabs/advanced.js
+++ b/src/js/tabs/advanced.js
@@ -20,8 +20,8 @@ AdvancedTab.prototype.generateHtml = function ()
 
 AdvancedTab.prototype.angular = function(module)
 {
-  module.controller('AdvancedCtrl', ['$scope', 'rpId', 'rpKeychain',
-                                    function ($scope, $id, $keychain)
+  module.controller('AdvancedCtrl', ['$scope', 'rpId', 'rpKeychain', 'rpNetwork',
+                                    function ($scope, $id, $keychain, $network)
   {
     // XRP currency object.
     // {name: "XRP - Ripples", order: 146, value: "XRP"}
@@ -69,9 +69,6 @@ AdvancedTab.prototype.angular = function(module)
 
       $scope.editBridge = false;
 
-      // Reload
-      location.reload();
-
       // Notify the user
       $scope.success.saveBridge = true;
     };
@@ -82,11 +79,11 @@ AdvancedTab.prototype.angular = function(module)
         $scope.options.max_tx_network_fee = ripple.Amount.from_human($scope.max_tx_network_fee_human).to_json();
         store.set('ripple_settings', JSON.stringify($scope.options));
       }
+      // This has to be updated manually because the network object is not
+      // recreated unless we do location.reload()
+      $network.remote.max_fee = $scope.options.max_tx_network_fee;
 
       $scope.editMaxNetworkFee = false;
-
-      // Reload
-      location.reload();
 
       // Notify the user
       $scope.success.saveMaxNetworkFee = true;
@@ -105,9 +102,6 @@ AdvancedTab.prototype.angular = function(module)
       }
 
       $scope.editAcctOptions = false;
-
-      // Reload
-      location.reload();
 
       // Notify the user
       $scope.success.saveAcctOptions = true;
@@ -214,11 +208,13 @@ AdvancedTab.prototype.angular = function(module)
           store.set('ripple_settings', JSON.stringify($scope.options));
         }
 
-        // Reload
-        location.reload();
-
         // Notify the user
         $scope.success.saveServer = true;
+
+        // Reload
+        // A force reload is necessary here because we have to re-initialize
+        // the network object with the new server list.
+        location.reload();
       };
     }
   ]);


### PR DESCRIPTION
Here are the affected parameters when `location.reload()` is removed:
1. Options.blobvault.
   js/services/oldblob.js

```
   165:      var url = Options.blobvault;
   180:      var url = Options.blobvault;
```

   This should fail because any services/*.js are not re-initialized unless we
   do location.reload().
   Fix: keep location.reload() intact for blobvault.

   js/entry/web.js

```
   243:if (!Options.blobvault) {
   244:  Options.blobvault = Options.BLOBVAULT_SERVER;
```

   This shouldn't matter because it is independent of the blobvault value.

   js/services/id.js

```
   278:      if(Options.blobvault) {
```

   This shouldn't matter because it is independent of the blobvault value.
1. Options.bridge.out.bitcoin.
   src/js/tabs/send.js

```
   147:        if (Options.bridge.out.bitcoin) { // And there is a default bridge
   148:          recipient += '@' + Options.bridge.out.bitcoin;
```

   Test: Change the value in Advanced, then go to Send.
   Result: This value updates successfully according to new settings.
1. Options.advanced_feature_switch.
   js/tabs/trust.js

```
   30:    $scope.advanced_feature_switch = Options.advanced_feature_switch;
```

   Test: Change the value in Advanced, then go to Trust.
   Result: This value updates successfully according to new settings.

   js/tabs/history.js

```
   76:    $scope.advanced_feature_switch = Options.advanced_feature_switch;
```

   Test: Change the value in Advanced, then go to History.
   Result: This value updates successfully according to new settings.
1. Options.max_tx_network_fee.
   src/js/services/network.js

```
   30:    this.remote.max_fee = Options.max_tx_network_fee || 12;
```

   Test: Change the value in Advanced, then go to any page.
   Result: Fails. Because max_tx_network_fee is assigned with pass-by-value.
   Fix: Add
      $network.remote.max_fee = $scope.options.max_tx_network_fee;
   in $scope.saveMaxNetworkFee.
1. Options.server.
   js/services/network.js

```
   25:    this.remote = new ripple.Remote(Options.server, true);
```

   This definitely requires a reload.
