### PR TITLE
[TASK] UI: Make base font consistent (RT-2747)

### DIFF
--- a/src/less/ripple/layout.less
+++ b/src/less/ripple/layout.less
@@ -5,7 +5,7 @@ html, body {
 }
 
 body {
-  font-family: sans-serif;
+  font-family: OpenSansRegular;
 }
 
 .nav a, .pagination a, .carousel a, .panel-title a { cursor: pointer; }
@@ -260,7 +260,6 @@ header {
         }
 
         &.active a {
-          font-family: 'OpenSansRegular';
           border-bottom: 2px solid @darkgray;
         }
       }
@@ -351,7 +350,7 @@ footer {
       padding-left:  (@grid-gutter-width / 6);
       padding-right: (@grid-gutter-width / 6);
     }
-    
+
   }
 }
 

--- a/src/less/ripple/status.less
+++ b/src/less/ripple/status.less
@@ -209,7 +209,7 @@
     -moz-transition-duration: 0.2s;
     -o-transition-duration: 0.2s;
     transition-duration: 0.2s;
-    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175); 
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
 
     &.active {
       top: 40px;
@@ -281,7 +281,6 @@
       padding-left: 10%;
       padding-right: 10%;
       font-size: 20px;
-      font-family: OpenSansRegular;
       line-height: 30px;
       opacity: 0;
       .rounded(5px);

--- a/src/less/ripple/tabs.less
+++ b/src/less/ripple/tabs.less
@@ -2497,7 +2497,7 @@ html.t-trade header nav ul > li.active#nav-advanced > a:after {
       padding-top: 10px;
       padding-bottom: 10px;
       .title {
-        font-family: 'Open Sans', sans-serif;
+        font-family: OpenSansBold;
         font-size: 12px;
         font-weight: 600;
         color: #1e1e1e;
@@ -2511,7 +2511,7 @@ html.t-trade header nav ul > li.active#nav-advanced > a:after {
       padding-right: 15px;
     }
     h4 {
-      font-family: 'Open Sans', sans-serif;
+      font-family: OpenSansBold;
       font-size: 12px;
       font-weight: 600;
       color: #1e1e1e;
@@ -2849,7 +2849,7 @@ html.t-trade header nav ul > li.active#nav-advanced > a:after {
 
 #t-gold, #t-jpy, #t-btc, #t-brl, #t-mxn {
   .title {
-    font-family: 'Open Sans', sans-serif;
+    font-family: OpenSansBold;
     font-size: 12px;
     color: #1e1e1e;
     font-weight: 600;
@@ -2913,7 +2913,6 @@ html.t-trade header nav ul > li.active#nav-advanced > a:after {
   .not-found-wrapper-row {
     padding: 70px 0 30px 0;
     a {
-      font-family: OpenSansRegular;
       font-size: 14px;
       &:hover {
         text-decoration: none;
@@ -2924,10 +2923,8 @@ html.t-trade header nav ul > li.active#nav-advanced > a:after {
       color: @midblue;
       margin: 0.67em 0;
       margin-bottom: 11px;
-      font-family: 'HelveticaNeueLTStd-UltLt', Helvetica, Arial, sans-serif;
     }
     .not-found-text {
-      font-family: 'HelveticaNeueLTStd-UltLt', Helvetica, Arial, sans-serif;
       margin-bottom: 11px;
       font-size: 24px;
       color: @darkgray;

--- a/src/less/ripple/widgets.less
+++ b/src/less/ripple/widgets.less
@@ -1,6 +1,5 @@
 .widgets {
   font-size: 14px;
-  font-family: 'OpenSansRegular';
   color: @black;
 
   .widget {


### PR DESCRIPTION
Replace the sans-serif default font with OpenSansRegular for all otherwise unstyled UI parts, drop unnecessary specific overrides.
- Before:
  ![2747-before](https://cloud.githubusercontent.com/assets/6348321/5183660/5cf97aa0-74b1-11e4-8373-8679403c46c6.jpg)
- After:
  ![2747-after](https://cloud.githubusercontent.com/assets/6348321/5183665/67c9ccfa-74b1-11e4-9ef4-26913e8bf3fe.jpg)

@mtrippled
