### PR TITLE
[FIX] Trust: Remove duplicate reserve warning (RT-2767)

### DIFF
--- a/src/jade/tabs/trust.jade
+++ b/src/jade/tabs/trust.jade
@@ -249,11 +249,6 @@ section.col-xs-12.content(ng-controller="TrustCtrl")
                   p.literal.verifying(ng-show="verifying")
                     img(src="img/button-s.png", class="loader")
                     span(class="loading_text", l10n) Verifying address
-          .col-xs-12(ng-show='addform_visible && !can_add_trust')
-            .alert.alert-warning(l10n) You must have at least
-              strong  {{account.reserve_to_add_trust | rpamount:0}} XRP
-              |  to add a new trust line.&#32;
-              a(href="https://ripple.com/wiki/Reserves", target="_blank") More information
 
         .row
           .unfunded.literal(ng-hide='account.Balance', l10n)


### PR DESCRIPTION
When trying to connect a gateway while there are insufficient reserve
funds, the yellow warning bar appeared twice: Once above the content,
once on the right of the currencies menu.

@rippletravis
- Before:
  ![before](https://cloud.githubusercontent.com/assets/6348321/5217244/207399e2-763e-11e4-93c2-53e1564218fc.jpg)
- After:
  ![after](https://cloud.githubusercontent.com/assets/6348321/5217246/24eebd44-763e-11e4-93e6-01762bd69ed0.jpg)
