### PR TITLE
[TASK] rename debug mode button (RT-2796)

### DIFF
--- a/src/jade/tabs/debug.jade
+++ b/src/jade/tabs/debug.jade
@@ -25,5 +25,5 @@ section.col-xs-12.content(ng-controller='DebugPretendCtrl')
       .row.row-padding-small.amount
         .col-xs-12.col-sm-9.col-md-6
           button.btn.btn-block.btn-success(type="submit", ng-disabled='debugPretendForm.$invalid',  l10n)
-            | Pretend
+            | Turn on debug mode
 


### PR DESCRIPTION
Debug mode button say 'turn on debug mode' rather than pretend

before
![rt-2796-before](https://cloud.githubusercontent.com/assets/2035357/5273378/faa712ca-7a8e-11e4-81fc-c9ae30657c35.jpg)

after
![rt-2796-after](https://cloud.githubusercontent.com/assets/2035357/5273380/ff156410-7a8e-11e4-8bb1-f252db2169f3.jpg)
