### PR TITLE
[TASK] debug message to standard color (RT-2798)

### DIFF
--- a/src/jade/client/navbar.jade
+++ b/src/jade/client/navbar.jade
@@ -1,9 +1,9 @@
 nav.navbar(role="navigation", ng-controller="NavbarCtrl")
   .alert.alert-warning(l10n, style="margin-bottom: 0;", ng-show="debug")
     | You are viewing an account in 
-    a(href="#/debug") Debug 
+    a(href="#/debug", class="text-warning", style="text-decoration: underline") Debug 
     | mode. While in this mode, you can view publicly available data, but you cannot initiate any transactions. Click 
-    a(href="", ng-click="page_reload()") here 
+    a(href="", ng-click="page_reload()", class="text-warning", style="text-decoration: underline") here 
     | to exit.
   .mainnav
     .container


### PR DESCRIPTION
change debug mode message to standard warning css class

after
![rt-2798-after](https://cloud.githubusercontent.com/assets/2035357/5273847/71b27e94-7a95-11e4-8b2a-6dfdb72509fc.jpg)
