### PR TITLE
[FEATURE] Trade: Display counter for orderbook age (RT-2330)

### DIFF
--- a/src/jade/tabs/trade.jade
+++ b/src/jade/tabs/trade.jade
@@ -482,6 +482,12 @@ section.col-xs-12.content(ng-controller="TradeCtrl")
               span(ng-show="hideOrderBook", l10n) show
               span(ng-hide="hideOrderBook", l10n) hide
           div(ng-hide="hideOrderBook")
+            .row.row-padding-small.orderbookupdate(ng-show="lastUpdate")
+              .col-xs-12.text-right(l10n) Last updated
+                span  {{lastUpdate}}
+                span(ng-show="lastUpdate > '1'", l10n-inc)  seconds
+                span(ng-show="lastUpdate == '1'", l10n-inc)  second
+                |  ago
             .listings.orders
               //- TODO hide one column (size/sum) to show bids/ask in the same line for mobile phones.
               //- TODO highlight changes

--- a/src/js/tabs/exchange.js
+++ b/src/js/tabs/exchange.js
@@ -141,7 +141,7 @@ ExchangeTab.prototype.angular = function (module)
               timer = setInterval(function(){
                 $scope.$apply(function(){
                   var seconds = Math.round((new Date() - lastUpdate) / 1000);
-                  $scope.lastUpdate = seconds ? seconds : 0;
+                  $scope.lastUpdate = seconds || 0;
                 });
               }, 1000);
 

--- a/src/js/tabs/send.js
+++ b/src/js/tabs/send.js
@@ -679,7 +679,7 @@ SendTab.prototype.angular = function (module)
           timer = setInterval(function(){
             $scope.$apply(function(){
               var seconds = Math.round((new Date() - lastUpdate) / 1000);
-              $scope.lastUpdate = seconds ? seconds : 0;
+              $scope.lastUpdate = seconds || 0;
             });
           }, 1000);
 

--- a/src/js/tabs/trade.js
+++ b/src/js/tabs/trade.js
@@ -38,6 +38,7 @@ TradeTab.prototype.angular = function(module)
                                             $rpTracker, keychain, $rootScope,
                                             popup, $anchorScroll ,$timeout)
   {
+    var timer;
     $scope.first_currency_selected = "";
     $scope.second_currency_selected = "";
 
@@ -1260,9 +1261,21 @@ TradeTab.prototype.angular = function(module)
 
     var rpamountFilter = $filter('rpamount');
 
+    var lastUpdate;
+
     $scope.$watchCollection('book', function () {
       if (! jQuery.isEmptyObject($scope.book) && $scope.book.ready) {
         $scope.editOrder.orderbookReady = true;
+
+        lastUpdate = new Date();
+
+        clearInterval(timer);
+        timer = setInterval(function(){
+          $scope.$apply(function(){
+            var seconds = Math.round((new Date() - lastUpdate) / 1000);
+            $scope.lastUpdate = seconds || 0;
+          });
+        }, 1000);
 
         ['asks','bids'].forEach(function(type){
           if ($scope.book[type]) {

--- a/src/less/ripple/tabs.less
+++ b/src/less/ripple/tabs.less
@@ -1583,7 +1583,7 @@
       }
     }
   }
-  .pathupdate {
+  .pathupdate, .orderbookupdate {
     font-size: 12px;
     color: @darkgray;
     margin-top: 10px;


### PR DESCRIPTION
I think the extra line
"Status: Current with latest ledger" is redundant with the display for
the orderbook age.

The age seems to follow a Poisson process with an average of 5s.
I have even observed the counter goes up to 60s before it resets.

The orderbook could be set to force-update after 30s timeout.
This likely solves the class of problems associated with orderbook
update.
