### PR TITLE
[TASK] Trade: Increase font size of fat finger err message

### DIFF
--- a/src/less/ripple/content.less
+++ b/src/less/ripple/content.less
@@ -46,7 +46,7 @@ h1 {
 
 .order-warning {
   color: @state-danger-text;
-  font: 24px 'OpenSansRegular';
+  font: 21px 'OpenSansSemibold';
   font-weight: normal;
 }
 


### PR DESCRIPTION
As requested by Phil.  We had some guy lose 30mm XRP overnight due to error message being too small / unnoticeable.
