### PR TITLE
[TASK] Trade: Force orderbook update every 30s (RT-2905)

### DIFF
--- a/src/js/tabs/trade.js
+++ b/src/js/tabs/trade.js
@@ -1292,6 +1292,13 @@ TradeTab.prototype.angular = function(module)
     });
 
     /**
+     * Force orderbook update every 30s
+     */
+    $scope.$watch(lastUpdate, function () {
+      if (lastUpdate > 30) loadOffers();
+    }, true);
+
+    /**
      * Watch widget field changes
      */
     ['buy','sell'].forEach(function(type){


### PR DESCRIPTION
Intended behavior:
`lastUpdate` counter resets only when `loadOffers()` changes the orderbook content.
So, expect the counter to go beyond 30 seconds from time to time.
