### PR TITLE
[FIX] Revert too strict JSCS fix for Jade l10n task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -291,7 +291,7 @@ module.exports = function(grunt) {
         ]
       }
     },
-    jadeL10nExtractor: {
+    jade_l10n_extractor: {
       templates: {
         options: {
         },


### PR DESCRIPTION
We need to use 'jade_l10n_extractor', not 'jadeL10nExtractor'.
