### PR TITLE
[FIX] Trade ui: tooltip overflow and underline fix

### DIFF
--- a/src/less/ripple/widgets.less
+++ b/src/less/ripple/widgets.less
@@ -297,6 +297,7 @@
         .btn-link {
           padding-left: 0px;
           padding-right: 0px;
+          text-decoration: none;
         }
 
         .btn-link[disabled] {
@@ -328,6 +329,7 @@
         }
 
         .action {
+          position: static;
           padding-left: 0;
           padding-right: 0;
         }


### PR DESCRIPTION
![trade-tooltip-1](https://cloud.githubusercontent.com/assets/1398736/5504924/a1be88e0-879b-11e4-8024-5a876de17f30.png)
