### PR TITLE
xrpchina rename

### DIFF
--- a/deps/gateways.json
+++ b/deps/gateways.json
@@ -63,7 +63,7 @@
             "hotwallets": []
             }]
     }, {
-        "name": "XRPChina",
+        "name": "DotPayco",
         "accounts": [{
             "address": "rM8199qFwspxiWNZRChZdZbGN5WrCepVP1",
             "currencies": ["CNY"],


### PR DESCRIPTION
I‘m a xrpchina's developer.
We are now renamed as dotpayco, but due to our negligence, did not retain xrpchina register name, and this name is register by other.

please accept this pull request
