### PR TITLE
[FEATURE] Send,Exchange: Show Network Fee in confirmation page

### DIFF
--- a/src/jade/tabs/exchange.jade
+++ b/src/jade/tabs/exchange.jade
@@ -126,14 +126,16 @@ section.col-xs-12.content(ng-controller="ExchangeCtrl")
             span.value {{exchange.alt.amount | rpamount}}&#32;
             span.currency {{exchange.alt.amount | rpcurrency}} &#32;
             span &plus; .1%
-          p.literal(l10n-inc) Are you sure?
-        .row.row-padding-small
-          .col-xs-6.col-sm-4.col-md-3.col-lg-2
-            button.btn.btn-block.btn-success.submit(type='submit'
-            ng-click='exchange_confirmed()'
-            ng-disabled='confirm_wait', l10n) Confirm
-          .col-xs-6.col-sm-4.col-md-3.col-lg-2
-            button.btn.btn-link.btn-default.back(ng-click='cancelConfirm()', l10n) cancel
+          span.literal(l10n-inc) Ripple network fee: 
+          span.literal(rp-pretty-amount='networkFee')
+          form.call-to-action(ng-submit='exchange_confirmed()')
+            p.literal(l10n-inc) Are you sure?
+            .row.row-padding-small
+              .col-xs-6.col-sm-4.col-md-3.col-lg-2
+                button.btn.btn-block.btn-success.submit(type='submit'
+                ng-disabled='confirm_wait', l10n) Confirm
+              .col-xs-6.col-sm-4.col-md-3.col-lg-2
+                button.btn.btn-link.btn-default.back(ng-click='cancelConfirm()', l10n) cancel
 
 
       //- N4. Waiting for transaction result page

--- a/src/jade/tabs/send.jade
+++ b/src/jade/tabs/send.jade
@@ -260,17 +260,19 @@ section.col-xs-12.content(ng-controller='SendCtrl')
         .dest_feedback
           .recipient(ng-show='send.recipient_name') {{send.recipient_name}}
           .recipient(ng-hide='send.recipient_name') {{send.recipient_address}}
-          .extra(href="", ng-show="send.recipient != send.recipient_address || send.recipient_name")
+          .extra(href='', ng-show='send.recipient != send.recipient_address || send.recipient_name')
             |  {{send.recipient_address}}
-          .dt(ng-show="send.dt", l10n) Destination tag: {{send.dt}}
+          .dt(ng-show='send.dt', l10n) Destination tag: {{send.dt}}
         p.literal(l10n) They will receive
-        p.amount_feedback(rp-pretty-amount="send.amount_feedback")
+        p.amount_feedback(rp-pretty-amount='send.amount_feedback')
         group(ng-show='send.indirect')
           p.literal(l10n) You will pay at most
           p.sendmax_feedback
             span.value {{send.alt.amount | rpamount}}&#32;
             span.currency {{send.alt.amount | rpcurrency}} &#32;
             span &plus; .1%
+        span.literal(l10n) Ripple network fee: 
+        span.literal(rp-pretty-amount='networkFee')
         form.call-to-action(ng-submit="send_confirmed()")
           p.literal(ng-show="send.secret", l10n) Are you sure?
           p.literal(ng-hide="send.secret", l10n) Please enter your password to confirm this transaction.

--- a/src/js/controllers/navbar.js
+++ b/src/js/controllers/navbar.js
@@ -35,7 +35,7 @@ module.controller('NavbarCtrl', ['$scope', '$element', '$compile', 'rpId',
     var username = $scope.userCredentials.username;
     $scope.shortUsername = null;
     if(username && username.length > 25) {
-      $scope.shortUsername = username.substring(0,24)+"...";
+      $scope.shortUsername = username.substring(0,24)+'...';
     }
   }, true);
 
@@ -71,7 +71,7 @@ module.controller('NavbarCtrl', ['$scope', '$element', '$compile', 'rpId',
 
     if (($scope.userBlob.data.lastSeenTxDate || 0) < lastTxDate) {
       // Remember last seen date
-      $scope.userBlob.set("/lastSeenTxDate", lastTxDate);
+      $scope.userBlob.set('/lastSeenTxDate', lastTxDate);
 
       // Reset the counter
       $scope.unseen = $scope.unseenNotifications.count;

--- a/src/js/filters/filters.js
+++ b/src/js/filters/filters.js
@@ -16,11 +16,11 @@ module.filter('rpamount', function () {
     var currency;
     var opts = jQuery.extend(true, {}, options);
 
-    if ("number" === typeof opts) {
+    if ('number' === typeof opts) {
       opts = {
         rel_min_precision: opts
       };
-    } else if ("object" !== typeof opts) {
+    } else if ('object' !== typeof opts) {
       opts = {};
     }
 

--- a/src/js/tabs/balance.js
+++ b/src/js/tabs/balance.js
@@ -241,7 +241,7 @@ BalanceTab.prototype.angular = function (module)
 
       getTx();
 
-      function getTx(){
+      function getTx() {
         network.remote.request_account_tx(params, function(err, data) {
           if (!data.transactions.length) {
             return callback(history);
@@ -280,7 +280,7 @@ BalanceTab.prototype.angular = function (module)
             getTx();
           }
         });
-      };
+      }
     };
 
     var changeDateRange = function(dateMin, dateMax) {

--- a/src/js/tabs/exchange.js
+++ b/src/js/tabs/exchange.js
@@ -264,6 +264,9 @@ ExchangeTab.prototype.angular = function (module)
           $scope.confirm_wait = false;
         }, 1000, true);
 
+        // compute network fee
+        $scope.networkFee = network.remote.transaction()._computeFee();
+
         $scope.mode = 'confirm';
       };
 

--- a/src/js/tabs/history.js
+++ b/src/js/tabs/history.js
@@ -150,7 +150,7 @@ HistoryTab.prototype.angular = function (module) {
             getTx();
           }
         });
-      };
+      }
     };
 
     // DateRange filter form

--- a/src/js/tabs/send.js
+++ b/src/js/tabs/send.js
@@ -924,6 +924,9 @@ SendTab.prototype.angular = function (module)
         delete $scope.send.pathfind;
       }
 
+      // compute network fee
+      $scope.networkFee = network.remote.transaction()._computeFee();
+
       $scope.mode = 'confirm';
 
       if (keychain.isUnlocked(id.account)) {

--- a/src/less/ripple/tabs.less
+++ b/src/less/ripple/tabs.less
@@ -1257,6 +1257,16 @@
     display: block;
   }
 
+  .toggle {
+    margin-left: 10px;
+    color: @midblue;
+    cursor: pointer;
+  }
+
+  .toggle:hover {
+    text-decoration: underline;
+  }
+
   .mode-form {
     .currency_force {
       margin-bottom: 20px;
@@ -2463,6 +2473,16 @@ header nav.navbar .open > .dropdown-menu {
     .big-icon {
       font-size: 70px;
     }
+  }
+
+  .toggle {
+    margin-left: 10px;
+    color: @midblue;
+    cursor: pointer;
+  }
+
+  .toggle:hover {
+    text-decoration: underline;
   }
 
   .mode-confirm {


### PR DESCRIPTION
Accidentally closed https://github.com/ripple/ripple-client/pull/2040 and the reopen button is disabled.

Latest text should look like:
You will pay at most
```undefined BTC \pm 1% ```
\+ Ripple network fee:   _Hide network fee_
``` 0.02 XRP ```