### PR TITLE
[FIX] Send: federation dt check (RT-1327)

### DIFF
--- a/src/js/tabs/send.js
+++ b/src/js/tabs/send.js
@@ -134,7 +134,7 @@ SendTab.prototype.angular = function (module)
           || (send.recipient_info &&
           'object' === typeof send.recipient_info &&
           send.recipient_info.dest_tag_required))
-          && !send.federation;
+          && (!send.federation || (send.federation_record && !send.federation_record.dt));
     };
 
     $scope.update_destination = function () {


### PR DESCRIPTION
If response from federation request not contains destination
tag, but destionation address requires it - show input field
for destination tag