### PR TITLE
[FIX] hide "Loading history" if unfunded (RT-3070)

### DIFF
--- a/src/jade/tabs/history.jade
+++ b/src/jade/tabs/history.jade
@@ -5,7 +5,7 @@ section.col-xs-12.content(ng-controller="HistoryCtrl")
   group.disconnected(ng-hide="connected")
     p.literal(l10n) You have to be online to see this screen
 
-  group.disconnected(ng-hide="!connected || loadState.transactions")
+  group.disconnected(ng-hide="!connected || loadState.transactions || (!loadingAccount && !account.Balance && loadState.account)")
     div(id="section_loader")
       img(src="img/sections.png", class="loader")
       div(class="loading_sections", l10n) Loading History


### PR DESCRIPTION
On an unfunded xrp wallet, on History page,
hide "Loading History" and spinning xrp