### PR TITLE
[FIX] rpamount error on small numbers (RT-3126)

### DIFF
--- a/src/js/filters/filters.js
+++ b/src/js/filters/filters.js
@@ -80,7 +80,9 @@ module.filter('rpamount', function() {
     if ((amtHuman < 0.01 && amtHuman > 0) ||
       ("number" === typeof opts.tiny_precision && amtHuman < 0.1)) {
         // We attempt to show the entire number, by setting opts.precision to a high number... 100
-        opts.precision = 100;
+      // opts.precision = 100;
+      // quick fix. Amount.to_human uses Number.toFixed, which throws RangeError for values larger then 20.
+      opts.precision = 20;
     }
 
     var cdp = ("undefined" !== typeof currency) ? currency : 4;


### PR DESCRIPTION
fix rpamount filter throwing RangeError on very small numbers
problem in ripple.Amount.to_human - it uses Number.toFixed and
does not check arguments. So we must either constrain toFixed
argument to maximum 20 or use some other implementation of toFixed