### PR TITLE
[FEATURE] Send URI: Add label, msg, info_url (RT-3048)

### DIFF
--- a/src/jade/tabs/send.jade
+++ b/src/jade/tabs/send.jade
@@ -18,6 +18,7 @@ section.col-xs-12.content(ng-controller='SendCtrl')
 
   div(ng-show='debug') This page is not available in debug mode
 
+  .alert.alert-info(ng-show='connected && $routeParams.label') {{$routeParams.label}}
   .row(ng-show='connected && !debug && account.Balance')
     .widgets.hidden-xs.col-sm-4.col-md-4.col-lg-3
       include widgets/balances

--- a/src/jade/tabs/tx.jade
+++ b/src/jade/tabs/tx.jade
@@ -5,12 +5,12 @@ section.single.ddpage.content(ng-controller="TxCtrl", ng-switch on="state")
       span(class="loading_text", l10n) Loading transaction details...
   group(ng-switch-when="error")
     p.literal(l10n) An error occurred while loading the transaction details.
-  group(ng-switch-when="loaded")
+  group(ng-switch-when='loaded')
     p.literal.hash
       span(l10n) Transaction #
       span(ng-bind="transaction.hash")
       div
-        a(href="{{'https://ripplecharts.com/#/graph/' + transaction.hash}}", target="_blank", l10n) Show in graph
+        a(href='{{"https://ripplecharts.com/#/graph/" + transaction.hash}}', target='_blank', l10n) Show in graph
     hr
     p.literal.type(l10n) Transaction type:
       strong(ng-bind="transaction.TransactionType")
@@ -51,17 +51,32 @@ section.single.ddpage.content(ng-controller="TxCtrl", ng-switch on="state")
               span :
             dd {{transaction.Fee | rpamount}} XRP
           dl.details.half
-            group(ng-show="transaction.DestinationTag !== null && transaction.DestinationTag !== undefined")
+            group(ng-show='transaction.DestinationTag !== null && transaction.DestinationTag !== undefined')
               dt
                 span(l10n) Destination tag
                 span :
               dd(ng-bind="transaction.DestinationTag")
         hr
+        group.clearfix
+          dl.details.half
+            dt
+              span(l10n) Ledger number
+              span :
+            dd(ng-bind="transaction.ledger")
+          dl.details.half
+            group(ng-show='info_url')
+              dt
+                span(l10n) Info URL
+                span :
+              dd
+                a(href='{{info_url}}', target='_blank', l10n) {{info_url}}
+        hr
         dl.details
-          dt
-            span(l10n) Ledger number
-            span :
-          dd(ng-bind="transaction.ledger")
+          group(ng-show='msg')
+            dt
+              span(l10n) Message
+              span :
+            dd(ng-bind='msg')
       group(ng-switch-default)
           group.clearfix
             dl.details.half

--- a/src/js/tabs/send.controller.js
+++ b/src/js/tabs/send.controller.js
@@ -1078,6 +1078,12 @@ SendTab.prototype.angular = function (module)
 
       // Add memo to tx
       tx.addMemo('client', 'rt' + $scope.version);
+      if ($routeParams.info_url) {
+        tx.addMemo('info_url', $routeParams.info_url);
+      }
+      if ($routeParams.msg) {
+        tx.addMemo('msg', $routeParams.msg);
+      }
 
       if (send.secret) {
         tx.secret(send.secret);
@@ -1105,7 +1111,7 @@ SendTab.prototype.angular = function (module)
         }
 
         if ('string' === typeof $scope.send.quote.invoice_id) {
-          tx.tx_json.InvoiceID = $scope.send.quote.invoice_id.toUpperCase();
+          tx.invoiceID = $scope.send.quote.invoice_id.toUpperCase();
         }
 
         tx.payment(id.account,

--- a/src/js/tabs/tx.controller.js
+++ b/src/js/tabs/tx.controller.js
@@ -36,6 +36,18 @@ TxTab.prototype.angular = function (module)
 
           $scope.transaction.ledger = data.transaction.ledger_index;
           $scope.transaction.amountSent = rewriter.getAmountSent(data.transaction.tx, data.transaction.meta);
+
+          // extract message and info_url from transaction memos
+          $scope.transaction.Memos.map(function(item) {
+            var memoType = ripple.utils.hexToString(item.Memo.MemoType);
+            var memoFormat = ripple.utils.hexToString(item.Memo.MemoFormat);
+            if (memoType === 'msg') {
+              $scope.msg = memoFormat;
+            } else if (memoType === 'info_url') {
+              $scope.info_url = memoFormat;
+            }
+          });
+
           $scope.state = 'loaded';
         })
         .error(function(){});


### PR DESCRIPTION
label
e.g. ```#/send?label=Every%20person%20on%20the%20street%20knows%20what%20is%20in%20your%20account.%20Please%20make%20a%20payment%20to%20proceed%3F```

![2015-02-03-172158_1177x329_scrot](https://cloud.githubusercontent.com/assets/395821/6018422/33cca298-abc9-11e4-9beb-5e0baeb7e9e2.png)

msg and info_url
e.g. ```#/send?msg=toward%20what%20end%3F&info_url=https://ripple.com``` see tx id ```#/tx?id=ECAA920B85D2C5043D20EE548ECA7E6236B3E1B198875AD6C8501D59B8BB3D34```
![2015-02-03-164720_1098x518_scrot](https://cloud.githubusercontent.com/assets/395821/6017819/5dc93fc0-abc4-11e4-9df8-6ac36ab408b8.png)

label is only visible to the user making payment, while msg and info_url are stored into the payment itself.