### PR TITLE
[TASK] Test: Disable coveralls reporter temporarily

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "license": "ISC",
   "scripts": {
     "test": "./node_modules/.bin/karma start test/karma.conf.js",
-    "test-travis": "./node_modules/.bin/karma start test/karma.conf.js --single-run --browsers Firefox && cat ./coverage/*/lcov.info | ./node_modules/.bin/coveralls"
+    "test-travis": "./node_modules/.bin/karma start test/karma.conf.js --single-run --browsers Firefox"
   },
   "repository": {
     "type": "git",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -16,7 +16,8 @@ module.exports = function(config) {
     autoWatch: true,
 
     // coverage
-    reporters: ['progress', 'coverage'],
+    // reporters: ['progress', 'coverage'],
+    reporters: ['progress'],
 
     preprocessors: {
       'src/js/**/*.js': ['coverage']


### PR DESCRIPTION
Until there is a clean solution around this. i.e. to run webpack once
again in karma.

Another way to make this work is to just put coverage in grunt +
istanbul, but then
this reduce the point of using karma in the first place?