### PR TITLE
[TASK] pagespeed perf: optimize img files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,6 +14,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-cache-bust');
   grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-cssmin');
+  grunt.loadNpmTasks('grunt-contrib-imagemin');
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-contrib-copy');
@@ -324,6 +325,17 @@ module.exports = function(grunt) {
         }]
       }
     },
+    imagemin: {
+      // note, this is done after 'copy' task so as not to rewrite the original img files
+      dynamic: {
+        files: [{
+          expand: true,
+          cwd: 'build/bundle/web/img/',
+          src: ['**/*.{png,svg,gif}'],
+          dest: 'build/bundle/web/img/'
+        }]
+      }
+    },
     jade_l10n_extractor: {
       templates: {
         options: {
@@ -505,6 +517,7 @@ module.exports = function(grunt) {
                                  'cssmin',
                                  'deps',
                                  'copy',
+                                 'imagemin',
                                  'cacheBust']);
 
   // Dev - builds the web version of the client excluding any locales

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "grunt-contrib-connect": "~0.5.0",
     "grunt-contrib-copy": "~0.4.1",
     "grunt-contrib-cssmin": "^0.12.1",
+    "grunt-contrib-imagemin": "^0.9.3",
     "grunt-contrib-uglify": "~0.2.7",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-jade-l10n-extractor": "~0.1.2",


### PR DESCRIPTION
Actually, css minification reduces the gzipped file by 4 KB.

For this case, the size reduction is
3.2 MB -> 2.7 for uncompressed img/
or
2.6 MB -> 2.5 MB for gzipped file