### PR TITLE
[TASK] Performance: Implement browser cache busting (RT-50)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -461,7 +461,7 @@ module.exports = function(grunt) {
         ]
       },
       output: {
-        filename: 'web/<%= pkg.name %>-debug.js'
+        filename: 'web/<%= pkg.name %>-<%= meta.version %>-debug.js'
       },
       debug: true,
       devtool: 'eval',
@@ -481,7 +481,7 @@ module.exports = function(grunt) {
         ]
       },
       output: {
-        filename: 'web/<%= pkg.name %>-' + language.code + '.js'
+        filename: 'web/<%= pkg.name %>-<%= meta.version %>-' + language.code + '.js'
       },
       optimize: {
         // TODO Minimization breaks our l10n mechanisms

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,6 +11,7 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-recess');
   grunt.loadNpmTasks('grunt-webpack');
   grunt.loadNpmTasks('grunt-preprocess');
+  grunt.loadNpmTasks('grunt-cache-bust');
   grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-cssmin');
   grunt.loadNpmTasks('grunt-contrib-uglify');
@@ -199,6 +200,19 @@ module.exports = function(grunt) {
         dest: 'build/dist/compat_nw-debug.js'
       }
     },
+    cacheBust: {
+      options: {
+        encoding: 'utf8',
+        algorithm: 'md5',
+        length: 16,
+        baseDir: 'build/bundle/web/'
+      },
+      assets: {
+        files: [{
+          src: ['build/bundle/web/index.html', 'build/bundle/web/index_debug.html', 'build/bundle/web/callback.html']
+        }]
+      }
+    },
     uglify: {
       // JavaScript dependencies
       deps: {
@@ -327,27 +341,27 @@ module.exports = function(grunt) {
       },
       scriptsDebug: {
         files: ['src/js/**/*.js', 'src/jade/**/*.jade'],
-        tasks: ['webpack:webDebug', 'copy'],
+        tasks: ['webpack:webDebug', 'copy', 'cacheBust'],
         options: { nospawn: true, livereload: true }
       },
       deps: {
         files: deps,
-        tasks: ['uglify:deps', 'uglify:individualDeps', 'concat:depsDebug', 'copy'],
+        tasks: ['uglify:deps', 'uglify:individualDeps', 'concat:depsDebug', 'copy', 'cacheBust'],
         options: { livereload: true }
       },
       styles: {
         files: 'src/less/**/*.less',
-        tasks: ['recess', 'cssmin', 'copy'],
+        tasks: ['recess', 'cssmin', 'copy', 'cacheBust'],
         options: { livereload: true }
       },
       index: {
         files: ['src/index.html'],
-        tasks: ['version', 'versionBranch', 'preprocess:webDebug', 'copy'],
+        tasks: ['version', 'versionBranch', 'preprocess:webDebug', 'copy', 'cacheBust'],
         options: { livereload: true }
       },
       callback: {
         files: ['src/callback.html'],
-        tasks: ['copy']
+        tasks: ['copy', 'cacheBust']
       },
       config: {
         files: ['src/js/config.js'],
@@ -490,7 +504,8 @@ module.exports = function(grunt) {
                                  'recess',
                                  'cssmin',
                                  'deps',
-                                 'copy']);
+                                 'copy',
+                                 'cacheBust']);
 
   // Dev - builds the web version of the client excluding any locales
   // Be sure to use English version for testing
@@ -503,7 +518,8 @@ module.exports = function(grunt) {
                              'recess',
                              'cssmin',
                              'deps',
-                             'copy']);
+                             'copy',
+                             'cacheBust']);
 
   // Deps only - only rebuilds the dependencies
   grunt.registerTask('deps', ['uglify:deps', 'uglify:individualDeps',

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "extend": "~1.2.1",
     "grunt": "~0.4.2",
     "grunt-bower-task": "~0.4.0",
+    "grunt-cache-bust": "^0.4.5",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-connect": "~0.5.0",
     "grunt-contrib-copy": "~0.4.1",

--- a/src/index.html
+++ b/src/index.html
@@ -116,7 +116,7 @@
 
       return resolveLanguage(store.get('ripple_language')) ||
              resolveLanguage(window.navigator.userLanguage || window.navigator.language) ||
-             "en";
+             'en';
     })();
     var debug = false;
   </script>
@@ -131,7 +131,8 @@
     $.ajaxSetup({
       cache: true
     });
-    $.getScript('js/ripple-client' + (debug ? '-debug' : '-'+lang) + '.js');
+    var version = '<!-- @echo VERSION -->';
+    $.getScript('js/ripple-client-' + version + (debug ? '-debug' : '-'+lang) + '.js');
   </script>
 
   <!-- start Mixpanel -->

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -7,7 +7,7 @@ module.exports = function(config) {
       'build/dist/deps-debug.js',
       'deps/js/angular-mocks/angular-mocks.js',
       'src/js/config.js',
-      'build/dist/web/ripple-client-debug.js',
+      'build/dist/web/ripple-client-*-debug.js',
       'test/unit/**/*.js'
     ],
 


### PR DESCRIPTION
Browser will update cache as needed whenever each assets is updated.
The update is atomic, which means, if a new ripple-client version changes only js files, then the rest of img, css caches will still remain.

For this to work, the expire header in server must be set to never.
