### PR TITLE
[FIX] Send: fix parsing destination tag (RT-3173)

### DIFF
--- a/src/js/directives/fields.js
+++ b/src/js/directives/fields.js
@@ -144,13 +144,13 @@ module.directive('rpCombobox', [function () {
           // Escape field value
           var escaped = webutil.escapeRegExp(match);
           // Build the regex for completion list lookup
-          re = new RegExp('('+escaped+')', 'i');
+          re = new RegExp('(' + escaped + ')', 'i');
 
           completions = complFn(match, re);
         }
 
         // Value as option
-        if (attrs.rpComboboxValueAsOption && match.length) {
+        if (attrs.rpComboboxValueAsOption && match && match.length) {
           var prefix = attrs.rpComboboxValueAsOptionPrefix;
 
           valueOption = (prefix && 0 !== match.indexOf(prefix))
@@ -161,7 +161,7 @@ module.directive('rpCombobox', [function () {
         }
 
         // Value as ripple name
-        if (attrs.rpComboboxValueAsRippleName && match.length) { // TODO Don't do a client check in validators
+        if (attrs.rpComboboxValueAsRippleName && match && match.length) { // TODO Don't do a client check in validators
           valueOption = (0 !== match.indexOf('~'))
             ? '~' + match
             : match;
@@ -187,7 +187,7 @@ module.directive('rpCombobox', [function () {
         completions.forEach(function (completion) {
           var additional = '';
 
-          if ("string" === typeof completion) {
+          if ('string' === typeof completion) {
             val = completion;
           } else {
             val = completion.name;

--- a/src/js/tabs/send.js
+++ b/src/js/tabs/send.js
@@ -86,7 +86,7 @@ SendTab.prototype.angular = function (module)
       $scope.update_currency();
 
       setImmediate(function() {
-        if ($scope.sendForm.send_amount !== undefined) {
+        if ($scope.sendForm && $scope.sendForm.send_amount !== undefined) {
           $scope.$apply(function() {
             // hack to re-validate input. remove this and uncomment $validate() when upgraded to angularjs 1.3
             $scope.sendForm.send_amount.$modelValue = '';
@@ -277,6 +277,7 @@ SendTab.prototype.angular = function (module)
             $scope.check_destination();
           } else {
             // this will trigger update
+            send.last_recipient = null;
             send.recipient = name;
           }
         }, function(err) {
@@ -707,7 +708,6 @@ SendTab.prototype.angular = function (module)
 
       send.alternatives = [];
     };
-
 
     $scope.update_paths = function () {
       var send = $scope.send;


### PR DESCRIPTION
reset last_recipient so when destination tag
is removed from address it will be rechecked

check if match var is defined before use