### PR TITLE
[FIX] Account&Settings: should still show page when rippled is down (RT-3196)

### DIFF
--- a/src/jade/tabs/account.jade
+++ b/src/jade/tabs/account.jade
@@ -1,7 +1,7 @@
 section.col-xs-12.content(ng-controller="AccountCtrl")
   div(ng-show='debug') This page is not available in debug mode
 
-  .row(ng-show='connected && !debug')
+  .row(ng-show='!debug')
     div(ng-show="!loadingAccount && !account.Balance && loadState.account && connected")
       include banner/unfunded
     .col-sm-3

--- a/src/jade/tabs/advanced.jade
+++ b/src/jade/tabs/advanced.jade
@@ -3,7 +3,7 @@ section.col-xs-12.content(ng-controller="AdvancedCtrl")
 
   div(ng-show="!loadingAccount && !account.Balance && loadState.account && connected && !debug")
     include banner/unfunded
-  .row(ng-show='connected && !debug')
+  .row(ng-show='!debug')
     .col-sm-12.notification-wrapper
       .alert.alert-success(ng-show="success.saveBlob", l10n) Your blobvault has been changed successfully.
       .alert.alert-success(ng-show="success.saveBridge", l10n) Your bitcoin bridge has been changed successfully.

--- a/src/jade/tabs/security.jade
+++ b/src/jade/tabs/security.jade
@@ -1,7 +1,7 @@
 section.col-xs-12.content(ng-controller="SecurityCtrl")
   div(ng-show='debug') This page is not available in debug mode
 
-  .row(ng-show='connected && !debug')
+  .row(ng-show='!debug')
     .col-xs-12(ng-hide="isUnlocked")
       .auth-attention.sessionUnlock
         h5(l10n) Active Session Timeout

--- a/src/jade/tabs/settingstrade.jade
+++ b/src/jade/tabs/settingstrade.jade
@@ -3,7 +3,7 @@ section.col-xs-12.content(ng-controller="SettingsTradeCtrl")
 
   div(ng-show="!loadingAccount && !account.Balance && loadState.account && connected && !debug")
     include banner/unfunded
-  .row(ng-show='connected && !debug')
+  .row(ng-show='!debug')
     .col-sm-12
     .col-sm-3
       include settings/navbar


### PR DESCRIPTION
And eventually History?