### PR TITLE
[FIX] Do not convert fees to Amount in history controller

### DIFF
--- a/src/js/tabs/history.controller.js
+++ b/src/js/tabs/history.controller.js
@@ -322,7 +322,7 @@ HistoryTab.prototype.angular = function (module) {
         lineTemplate.Date = dateTime.format('YYYY-MM-DD');
         lineTemplate.Time = dateTime.format('HH:mm:ss');
         lineTemplate.LedgerNum = histLine.ledger_index;
-        lineTemplate.Fee = formatAmount(Amount.from_json(histLine.fee));
+        lineTemplate.Fee = formatAmount(histLine.fee);
         lineTemplate.TransHash = histLine.hash;
 
         // Default type-specific fields to NA, they will be overridden later if applicable


### PR DESCRIPTION
It's not needed anymore because fees are converted to Amount objects in jsonrewriter

A little fix related to updated jsonrewriter behaviour