### PR TITLE
[FEATURE] Dismiss locale popup on Esc (RT-3280)

### DIFF
--- a/src/js/directives/directives.directive.js
+++ b/src/js/directives/directives.directive.js
@@ -56,6 +56,16 @@ module.directive('rpPopup', ['rpPopup', '$parse', function(popup, $parse) {
       a.click(function(e) {
         e.preventDefault();
 
+        var dismissOnEsc = function($event) {
+          // esc button
+          if ($event.which === 27) {
+            $(document).off('keyup', dismissOnEsc);
+            popup.close();
+          }
+        };
+
+        $(document).on('keyup', dismissOnEsc);
+
         // onShow action
         if (attrs.rpPopupOnOpen) {
           $parse(attrs.rpPopupOnOpen)(scope);


### PR DESCRIPTION
Use `rp-popup(rp-popup-dismiss-on-esc)` attribute to allow dismissing the popup when the user presses the [Esc] key while the popup is shown.