### PR TITLE
[FIX] Btc2ripple: show appropriate error(RT-3334)

### DIFF
--- a/src/js/tabs/btc.controller.js
+++ b/src/js/tabs/btc.controller.js
@@ -21,6 +21,7 @@ BtcTab.prototype.angular = function (module)
     $scope.showInstructions = false;
     $scope.btcConnected = false;
     $scope.emailError = false;
+    $scope.generalError = false;
 
     $scope.toggle_instructions = function () {
       $scope.showInstructions = !$scope.showInstructions;
@@ -28,6 +29,7 @@ BtcTab.prototype.angular = function (module)
 
     $scope.openPopup = function () {
       $scope.emailError = false;
+      $scope.generalError = false;
       rpTracker.track('B2R Show Connect');
     };
 
@@ -50,14 +52,14 @@ BtcTab.prototype.angular = function (module)
 
       fields.rippleAddress = id.account;
       fields.email = $scope.userBlob.data.email;
- 
+
       keychain.requestSecret(id.account, id.username, function (err, secret) {
         if (err) {
           console.log("client: trust profile: error while " +
             "unlocking wallet: ", err);
           $scope.mode = "error";
           $scope.error_type = "unlockFailed";
-  
+
           return;
         }
 
@@ -73,9 +75,14 @@ BtcTab.prototype.angular = function (module)
         $scope.B2RApp.findProfile('account').signup(fields, function (err, response) {
           if (err) {
             console.log('Error', err);
-            $scope.emailError = true;
+            if (err && err.message == 'E-mail address is not accepted') {
+              $scope.load_notification('emailError');
+              $scope.emailError = true;
+            } else {
+              $scope.load_notification('error');
+              $scope.generalError = true;
+            }
             $scope.btcConnected = false;
-            $scope.load_notification('error');
 
             rpTracker.track('B2R SignUp', {
               result: 'failed',

--- a/src/templates/tabs/btc.jade
+++ b/src/templates/tabs/btc.jade
@@ -25,6 +25,8 @@ section.col-xs-12.content(ng-controller='BtcCtrl')
       group.result-error(ng-switch-when="error")
         h2.tx-status(l10n) There was an error with your request.&#32;
           p(l10n) Please try again later.
+      group.result-error(ng-switch-when="emailError")
+        h2.tx-status(l10n) There was an error with your request.&#32;
 
   .row(ng-show='connected')
     .col-sm-3
@@ -94,9 +96,12 @@ section.col-xs-12.content(ng-controller='BtcCtrl')
                 .description(ng-hide="btcConnected")
                   i.fa.fa-times
                   span(l10n) Not connected
-              span.error(ng-show="emailError", l10n)
+              span.error(ng-show="generalError", l10n)
                 | SnapSwap's btc2ripple service is currently unavailable.
                 |  Please check back later.
+              span.error(ng-show="emailError", l10n)
+                | You’ve already used this email address to generate a bitcoin receiving address in Ripple Trade.
+                | Please contact support@btc2ripple.com if you want to use this Ripple Trade account instead.
         .row(ng-show="btcConnected && showInstructions")
           .instructions.col-md-10
             //a.dismiss#hide(href="", ng-click="toggle_instructions()")  ×


### PR DESCRIPTION
Btc2ripple: show appropriate error message when you've
already signed up for btc2ripple using another email address