### PR TITLE
[FIX] Send: alert about min btc size (RT-3360)

### DIFF
--- a/src/js/tabs/send.controller.js
+++ b/src/js/tabs/send.controller.js
@@ -387,6 +387,7 @@ SendTab.prototype.angular = function (module)
       // Reset constraints
       send.currency_choices = $scope.currencies_all;
       send.currency_force = false;
+      send.currencyIsBTC = false;
 
       send.currency_choices_constraints = {};
 
@@ -485,11 +486,13 @@ SendTab.prototype.angular = function (module)
 
       if (currencies.length === 1) {
         send.currency = send.currency_force = currencies[0];
+        send.currencyIsBTC = _.startsWith(send.currency_force, 'BTC');
       } else if (currencies.length === 0) {
         send.path_status = 'error-no-currency';
         send.currency = '';
       } else {
         send.currency_force = false;
+        send.currencyIsBTC = false;
 
         if (currencies.indexOf(send.currency) === -1) {
           send.currency = currencies[0];

--- a/src/templates/tabs/send.jade
+++ b/src/templates/tabs/send.jade
@@ -155,6 +155,11 @@ section.col-xs-12.content(ng-controller='SendCtrl')
               rp-amount-currency='{{send.currency}}'
               rp-max-digits)
               span.input-group-addon(ng-bind="send.currency_force")
+          .row(ng-if="send.currencyIsBTC")
+            .col-xs-12.col-sm-6.col-md-6
+              .alert.alert-warning(l10n)
+                | The minimum BTC transaction size is .001 BTC. 
+                a(href="https://b2r.uservoice.com/knowledgebase/articles/393152-is-there-a-minimum-transaction-size", target="_blank", l10n-inc) More info
           .errorGroup(ng-messages='sendForm.send_amount_currency.$error')
             .error(ng-message='rpRestrictCurrencies', l10n) {{send.recipient | rpcontactname}} can't receive this currency.
           .errorGroup(ng-messages='sendForm.send_amount.$dirty && sendForm.send_amount.$error')


### PR DESCRIPTION
When sending to a BTC address, show text to indicate that minimum
transaction size is .001 BTC