### PR TITLE
[FIX] Trust: fix e-notation in edit (RT-3250)

### DIFF
--- a/src/js/tabs/trust.controller.js
+++ b/src/js/tabs/trust.controller.js
@@ -389,7 +389,8 @@ TrustTab.prototype.angular = function (module)
         $scope.editing = true;
 
         $scope.trust = {};
-        $scope.trust.limit = Number($scope.component.limit.to_json().value);
+        // edit as string because Chrome shows tiny numbers in e-notation
+        $scope.trust.limit = String($scope.component.limit.to_json().value);
         $scope.trust.rippling = !$scope.component.no_ripple;
         $scope.trust.limit_peer = Number($scope.component.limit_peer.to_json().value);
         $scope.trust.balance = String($scope.component.balance.to_json().value);


### PR DESCRIPTION
Fix for Chrome showing very low trust limits in edit
field in e-notation.