### PR TITLE
[FIX] Rename some settings tabs (RT-3381)

### DIFF
--- a/src/templates/tabs/settings/navbar.jade
+++ b/src/templates/tabs/settings/navbar.jade
@@ -1,6 +1,6 @@
 .settingPage
   a(href="#/security", ng-class="{active: $route.current.tabName == 'security'}", l10n) Security
   a(href="#/settingstrade", ng-class="{active: $route.current.tabName == 'settingstrade'}", l10n) Trade
-  a(href="#/advanced", ng-class="{active: $route.current.tabName == 'advanced'}", l10n) Advanced
-  a(href="#/settingsgateway", ng-class="{active: $route.current.tabName == 'settingsgateway'}", l10n) Gateways
-  a(href="#/notifications", ng-class="{active: $route.current.tabName == 'notifications'}", l10n) Notifications
+  a(href="#/advanced", ng-class="{active: $route.current.tabName == 'advanced'}", l10n) Network and servers
+  a(href="#/settingsgateway", ng-class="{active: $route.current.tabName == 'settingsgateway'}", l10n) Gateways and trust lines
+  //- a(href="#/notifications", ng-class="{active: $route.current.tabName == 'notifications'}", l10n) Notifications


### PR DESCRIPTION
1) Comment out the notifications tab for now (we don't have notifications live yet)
2) Rename "Advanced" to "Network and servers"
3) Rename Gateways to "Gateways and trust lines"