### PR TITLE
[FIX] handle change to async validators (RT-3204)

### DIFF
--- a/src/templates/tabs/account/public.jade
+++ b/src/templates/tabs/account/public.jade
@@ -54,7 +54,7 @@ h4(l10n) Account settings
         .row
           .col-xs-12.col-sm-6
             button.btn.btn-success.btn-block(type="submit"
-            ng-disabled="renameForm.$invalid || loading")
+            ng-disabled="renameForm.$invalid || loading || renameForm.$pending")
               span(ng-hide="loading", l10n) Submit
               span(ng-show="loading", l10n) Loading...
           .col-xs-12.col-sm-6

--- a/src/templates/tabs/contacts.jade
+++ b/src/templates/tabs/contacts.jade
@@ -90,7 +90,7 @@ section.col-xs-12.content(ng-controller="ContactsCtrl")
               .error(ng-message='rpUnique', l10n) You already have a contact with the same Ripple name and/or the same Destination tag.
         .row
           .col-xs-8.col-sm-8.col-md-9.text-left
-            button.btn.btn-success.btn-block.submit.custom-btn(type='submit', ng-disabled='addForm.$invalid', l10n) Add contact
+            button.btn.btn-success.btn-block.submit.custom-btn(type='submit', ng-disabled='addForm.$invalid || addForm.$pending', l10n) Add contact
           .col-xs-4.col-sm-4.col-md-3.text-center
             button.btn.btn-default.btn-block.custom-btn.btn-cancel(type='button', ng-click='addform_visible = false', l10n) cancel
 

--- a/src/templates/tabs/debug.jade
+++ b/src/templates/tabs/debug.jade
@@ -22,6 +22,6 @@ section.col-xs-12.content(ng-controller='DebugPretendCtrl')
         .error(ng-message='rpDest', l10n) Not a valid address.
       .row.row-padding-small.amount
         .col-xs-12.col-sm-9.col-md-6
-          button.btn.btn-block.btn-success(type="submit", ng-disabled='debugPretendForm.$invalid',  l10n)
+          button.btn.btn-block.btn-success(type="submit", ng-disabled='debugPretendForm.$invalid || debugPretendForm.$pending',  l10n)
             | Turn on debug mode
 

--- a/src/templates/tabs/send.jade
+++ b/src/templates/tabs/send.jade
@@ -177,7 +177,7 @@ section.col-xs-12.content(ng-controller='SendCtrl')
         .row
           .col-xs-12.col-sm-6.col-md-4(ng-show="send.currency_code == 'XRP'")
             button#sendXrpButton.btn.btn-block.btn-success.submit(type='submit'
-            ng-disabled='sendForm.$invalid || send.self || send.insufficient || !send.recipient_resolved || account.max_spend.to_number() < send.amount * 1000000', l10n)
+            ng-disabled='sendForm.$invalid || sendForm.$pending || send.self || send.insufficient || !send.recipient_resolved || account.max_spend.to_number() < send.amount * 1000000', l10n)
               | Send XRP
         .remote
           //- Messages
@@ -240,7 +240,7 @@ section.col-xs-12.content(ng-controller='SendCtrl')
                       span.pair {{alt.amount | rpcurrency}}/{{send.currency_code}}
                       | )
                   button.btn.btn-block.btn-success(type="submit"
-                  ng-disabled='sendForm.$invalid', ng-click="send.alt = alt", l10n)
+                  ng-disabled='sendForm.$invalid || sendForm.$pending', ng-click="send.alt = alt", l10n)
                     | Send {{ alt.amount | rpcurrency }}
                     span(ng-hide="alt.amount.is_native() || alt.amount.issuer().to_json() == account.Account")  (
                       span.issuer(

--- a/src/templates/tabs/trade.jade
+++ b/src/templates/tabs/trade.jade
@@ -78,7 +78,7 @@ section.col-xs-12.content(ng-controller="TradeCtrl")
             .col-sm-4.col-lg-2.col-xs-6#cancel_button
               button.btn.btn-cancel.btn-block(type="button", ng-click="adding_pair = false", l10n) cancel
             .col-sm-4.col-lg-2.col-xs-6#add_button
-              button.btn.btn-success.btn-block.submit(type="submit", ng-disabled="gateway_change_form.$invalid", l10n) Add
+              button.btn.btn-success.btn-block.submit(type="submit", ng-disabled="gateway_change_form.$invalid || gateway_change_form.$pending", l10n) Add
 
         form.issuerSelector.first-issuer(name='first_issuer_form', ng-show='show_issuer_form == "first"')
           label(for='first_issuer', l10n) Base currency issuer ({{order.first_currency | rpcurrency}})


### PR DESCRIPTION
In forms that use rpAvailableName or rpDest check not
only for $invalid, but for $pending too.
On send tab better handle changes to recipient address
when form invalidates.