### PR TITLE
[FIX] Custom gateways: do not show Add (RT-3340)

### DIFF
--- a/src/templates/tabs/brl.jade
+++ b/src/templates/tabs/brl.jade
@@ -74,20 +74,23 @@ section.col-xs-12.content(ng-controller='BrlCtrl')
 
       .row.fund-tab-description
         .col-xs-7.col-sm-5.col-md-4.action-btn-wrapper
-          button.btn.btn-large.btn-primary(type="submit",ng-click="save_account()", ng-hide="brlConnected", ng-disabled="loading || !account.Balance || !can_add_trust")
+          button.btn.btn-large.btn-primary(type="submit",ng-click="save_account()", ng-hide="brlConnected || !loadState.account", ng-disabled="loading || !account.Balance || !can_add_trust")
             span(ng-show="!loading", l10n)  Add Rippex
             span(ng-show="loading", l10n)  Adding...
           button.btn.btn-large.btn-primary(ng-show="showInstructions && brlConnected", type="submit", ng-click="toggle_instructions()", l10n) Hide instructions
           button.btn.btn-large.btn-primary(ng-show="!showInstructions && brlConnected ", type="submit", ng-click="toggle_instructions()", l10n) Show instructions
 
         .connect.col-xs-5.col-sm-7.col-md-8
-          .description(ng-show="!brlConnected && account.Balance", l10n) 
+          .description(ng-show="!brlConnected && account.Balance && !loadingAccount", l10n) 
             i.fa.fa-times
             | Not connected
-          .description(ng-show="brlConnected && account.Balance", l10n) 
+          .description(ng-show="brlConnected && account.Balance && !loadingAccount", l10n) 
             i.fa.fa-check
             | Connected
-          .description(ng-show="!account.Balance", l10n) Your account has to be activated before you can add a gateway account.
+          .description(ng-show="!account.Balance && loadState.account", l10n) Your account has to be activated before you can add a gateway account.
+          .description(ng-show="!loadState.account")
+            img(src="img/button-s.png", class="loader")
+            span(class="loading_text", l10n) Loading...
       .row.fund-tab-description(ng-show="showInstructions && brlConnected")
         .instructions.col-md-10
           a.dismiss(href="", id="hide", ng-click="toggle_instructions()", l10n)  ×

--- a/src/templates/tabs/btc.jade
+++ b/src/templates/tabs/btc.jade
@@ -61,7 +61,7 @@ section.col-xs-12.content(ng-controller='BtcCtrl')
               .col-xs-7.col-sm-5.col-md-4
                 rp-popup
                   a.btn.btn-success.btn-sm.btn-block.sign(href="", rp-popup-link,
-                    ng-click="openPopup()", ng-show="!btcConnected && !loading", ng-disabled="emailError", ng-hide="btcConnected",l10n) Add btc2ripple
+                    ng-click="openPopup()", ng-show="!btcConnected && !loading && !loadingAccount && loadState.B2RApp", ng-disabled="emailError", ng-hide="btcConnected",l10n) Add btc2ripple
                   div.connectModal(rp-popup-content)
                     .modal-header
                       .navbar-brand.hidden-sm.modal-logo#logo

--- a/src/templates/tabs/eur.jade
+++ b/src/templates/tabs/eur.jade
@@ -69,7 +69,7 @@ section.col-xs-12.content(ng-controller='EurCtrl')
 
       .row.fund-tab-description
         .col-xs-7.col-sm-5.col-md-4
-          button.btn.btn-large.btn-primary(ng-show="!eurConnected && !loading", type="submit", ng-click="save_account()", ng-disabled="!account.Balance || !can_add_trust", l10n) Add SnapSwap.eu
+          button.btn.btn-large.btn-primary(ng-show="!eurConnected && !loading && loadState.account", type="submit", ng-click="save_account()", ng-disabled="!account.Balance || !can_add_trust", l10n) Add SnapSwap.eu
           button.btn.btn-large.btn-primary(ng-show="!eurConnected && loading", type="submit", ng-disabled="loading", l10n) Adding...
           button.btn.btn-large.btn-primary(ng-show="showInstructions && eurConnected", type="submit", ng-click="toggle_instructions()", l10n) Hide instructions
           button.btn.btn-large.btn-primary(ng-show="eurConnected && !showInstructions", type="submit", ng-click="toggle_instructions()", l10n) Show instructions
@@ -77,7 +77,10 @@ section.col-xs-12.content(ng-controller='EurCtrl')
         .connect.col-xs-5.col-sm-7.col-md-8(ng-hide="loading")
           .description.fa.fa-times(ng-show="!eurConnected && account.Balance", l10n) Not connected
           .description.fa.fa-check(ng-show="eurConnected && account.Balance", l10n) Connected
-          .description(ng-show="!account.Balance", l10n) Your account has to be activated before you can add a gateway account.
+          .description(ng-show="!account.Balance && loadState.account", l10n) Your account has to be activated before you can add a gateway account.
+          .description(ng-show="!loadState.account")
+            img(src="img/button-s.png", class="loader")
+            span(class="loading_text", l10n) Loading...
 
       .row(ng-show="showInstructions && eurConnected")
         .instructions.col-md-10

--- a/src/templates/tabs/gold.jade
+++ b/src/templates/tabs/gold.jade
@@ -67,7 +67,7 @@ section.col-xs-12.content(ng-controller='GoldCtrl')
 
       .row.fund-tab-description
         .col-xs-7.col-sm-5.col-md-4
-          button.btn.btn-large.btn-primary(ng-show="!gbiConnected && !loading", type="submit", ng-click="save_account()", ng-disabled="!account.Balance || !can_add_trust", l10n) Add GBI
+          button.btn.btn-large.btn-primary(ng-show="!gbiConnected && !loading && loadState.account", type="submit", ng-click="save_account()", ng-disabled="!account.Balance || !can_add_trust", l10n) Add GBI
           button.btn.btn-large.btn-primary(ng-show="!gbiConnected && loading", type="submit", ng-disabled="loading", l10n) Adding...
           button.btn.btn-large.btn-primary(ng-show="showInstructions && gbiConnected", type="submit", ng-click="toggle_instructions()", l10n) Hide instructions
           button.btn.btn-large.btn-primary(ng-show="gbiConnected && !showInstructions", type="submit", ng-click="toggle_instructions()", l10n) Show instructions
@@ -79,7 +79,10 @@ section.col-xs-12.content(ng-controller='GoldCtrl')
           .description(ng-show="gbiConnected && account.Balance", l10n) 
             i.fa.fa-check
             |  Connected
-          .description(ng-show="!account.Balance", l10n) Your account has to be activated before you can add a gateway account.
+          .description(ng-show="!account.Balance && loadState.account", l10n) Your account has to be activated before you can add a gateway account.
+          .description(ng-show="!loadState.account")
+            img(src="img/button-s.png", class="loader")
+            span(class="loading_text", l10n) Loading...
       .row(ng-show="showInstructions && gbiConnected")
         .instructions.col-md-10
           a.dismiss#hide(href="", ng-click="toggle_instructions()", l10n)  ×

--- a/src/templates/tabs/jpy.jade
+++ b/src/templates/tabs/jpy.jade
@@ -68,7 +68,7 @@ section.col-xs-12.content(ng-controller='JpyCtrl')
           .descriptor(ng-show="!jpyConnected", l10n) Ripple Trade has partnered with Tokyo JPY Issuer to provide easier access to JPY. Following this action will enable Tokyo JPY Issuer to hold JPY on your behalf.
       .row.fund-tab-description
         .col-xs-7.col-sm-5.col-md-4
-          button.btn.btn-large.btn-primary(ng-show="!jpyConnected && !loading", type="submit", ng-click="save_account()", ng-disabled="!account.Balance || !can_add_trust", l10n) Add Tokyo JPY
+          button.btn.btn-large.btn-primary(ng-show="!jpyConnected && !loading && loadState.account", type="submit", ng-click="save_account()", ng-disabled="!account.Balance || !can_add_trust", l10n) Add Tokyo JPY
           button.btn.btn-large.btn-primary(ng-show="!jpyConnected && loading", type="submit", ng-disabled="loading", l10n) Adding...
           button.btn.btn-large.btn-primary(ng-show="showInstructions && jpyConnected", type="submit", ng-click="toggle_instructions()", l10n) Hide instructions
           button.btn.btn-large.btn-primary(ng-show="jpyConnected && !showInstructions", type="submit", ng-click="toggle_instructions()", l10n) Show instructions
@@ -80,7 +80,10 @@ section.col-xs-12.content(ng-controller='JpyCtrl')
           .description(ng-show="jpyConnected && account.Balance", l10n) 
             i.fa.fa-check
             |  Connected
-          .description(ng-show="!account.Balance", l10n) Your account has to be activated before you can add a gateway account.
+          .description(ng-show="!account.Balance && loadState.account", l10n) Your account has to be activated before you can add a gateway account.
+          .description(ng-show="!loadState.account")
+            img(src="img/button-s.png", class="loader")
+            span(class="loading_text", l10n) Loading...
       .row(ng-show="showInstructions && jpyConnected")
         .instructions.col-md-10
           a.dismiss(href="", id="hide", ng-click="toggle_instructions()", l10n)  ×

--- a/src/templates/tabs/mxn.jade
+++ b/src/templates/tabs/mxn.jade
@@ -70,7 +70,7 @@ section.col-xs-12.content(ng-controller='MxnCtrl')
 
       .row.fund-tab-description
         .col-xs-7.col-sm-5.col-md-4
-          button.btn.btn-large.btn-primary(ng-show="!mxnConnected && !loading", type="submit", ng-click="save_account()", ng-disabled="!account.Balance || !can_add_trust", l10n) Add Bitso
+          button.btn.btn-large.btn-primary(ng-show="!mxnConnected && !loading && loadState.account", type="submit", ng-click="save_account()", ng-disabled="!account.Balance || !can_add_trust", l10n) Add Bitso
           button.btn.btn-large.btn-primary(ng-show="!mxnConnected && loading", type="submit", ng-disabled="loading", l10n) Adding...
           button.btn.btn-large.btn-primary(ng-show="showInstructions && mxnConnected", type="submit", ng-click="toggle_instructions()", l10n) Hide instructions
           button.btn.btn-large.btn-primary(ng-show="mxnConnected && !showInstructions", type="submit", ng-click="toggle_instructions()", l10n) Show instructions
@@ -82,7 +82,10 @@ section.col-xs-12.content(ng-controller='MxnCtrl')
           .description(ng-show="mxnConnected && account.Balance", l10n) 
             i.fa.fa-check
             |  Connected
-          .description(ng-show="!account.Balance", l10n) Your account has to be activated before you can add a gateway account.
+          .description(ng-show="!account.Balance && loadState.account", l10n) Your account has to be activated before you can add a gateway account.
+          .description(ng-show="!loadState.account")
+            img(src="img/button-s.png", class="loader")
+            span(class="loading_text", l10n) Loading...
       .row(ng-show="showInstructions && mxnConnected")
         .instructions.col-md-10
           a.dismiss#hide(href="", ng-click="toggle_instructions()", l10n)  ×

--- a/src/templates/tabs/sgd.jade
+++ b/src/templates/tabs/sgd.jade
@@ -69,7 +69,7 @@ section.col-xs-12.content(ng-controller='SgdCtrl')
 
       .row.fund-tab-description
         .col-xs-7.col-sm-5.col-md-4
-          button.btn.btn-large.btn-primary(ng-show="!sgdConnected && !loading", type="submit", ng-click="save_account()", ng-disabled="!account.Balance || !can_add_trust", l10n) Add Ripple Singapore
+          button.btn.btn-large.btn-primary(ng-show="!sgdConnected && !loading && loadState.account", type="submit", ng-click="save_account()", ng-disabled="!account.Balance || !can_add_trust", l10n) Add Ripple Singapore
           button.btn.btn-large.btn-primary(ng-show="!sgdConnected && loading", type="submit", ng-disabled="loading", l10n) Adding...
           button.btn.btn-large.btn-primary(ng-show="showInstructions && sgdConnected", type="submit", ng-click="toggle_instructions()", l10n) Hide instructions
           button.btn.btn-large.btn-primary(ng-show="sgdConnected && !showInstructions", type="submit", ng-click="toggle_instructions()", l10n) Show instructions
@@ -81,7 +81,10 @@ section.col-xs-12.content(ng-controller='SgdCtrl')
           .description(ng-show="sgdConnected && account.Balance", l10n)
             i.fa.fa-check
             |  Connected
-          .description(ng-show="!account.Balance", l10n) Your account has to be activated before you can add a gateway account.
+          .description(ng-show="!account.Balance && loadState.account", l10n) Your account has to be activated before you can add a gateway account.
+          .description(ng-show="!loadState.account")
+            img(src="img/button-s.png", class="loader")
+            span(class="loading_text", l10n) Loading...
 
       .row(ng-show="showInstructions && sgdConnected")
         .instructions.col-md-10

--- a/src/templates/tabs/usd.jade
+++ b/src/templates/tabs/usd.jade
@@ -66,7 +66,7 @@ section.col-xs-12.content(ng-controller='UsdCtrl')
 
       .row.fund-tab-description
         .col-xs-7.col-sm-5.col-md-4
-          button.btn.btn-large.btn-primary(ng-show="!usdConnected && !loading", type="submit", ng-click="save_account()", ng-disabled="!account.Balance || !can_add_trust", l10n) Add SnapSwap.us
+          button.btn.btn-large.btn-primary(ng-show="!usdConnected && !loading && loadState.account", type="submit", ng-click="save_account()", ng-disabled="!account.Balance || !can_add_trust", l10n) Add SnapSwap.us
           button.btn.btn-large.btn-primary(ng-show="!usdConnected && loading", type="submit", ng-disabled="loading", l10n) Adding...
           button.btn.btn-large.btn-primary(ng-show="showInstructions && usdConnected", type="submit", ng-click="toggle_instructions()", l10n) Hide instructions
           button.btn.btn-large.btn-primary(ng-show="usdConnected && !showInstructions", type="submit", ng-click="toggle_instructions()", l10n) Show instructions
@@ -74,7 +74,10 @@ section.col-xs-12.content(ng-controller='UsdCtrl')
         .connect.col-xs-5.col-sm-7.col-md-8(ng-hide="loading")
           .description.fa.fa-times(ng-show="!usdConnected && account.Balance", l10n) Not connected
           .description.fa.fa-check(ng-show="usdConnected && account.Balance", l10n) Connected
-          .description(ng-show="!account.Balance", l10n) Your account has to be activated before you can add a gateway account.
+          .description(ng-show="!account.Balance && loadState.account", l10n) Your account has to be activated before you can add a gateway account.
+          .description(ng-show="!loadState.account")
+            img(src="img/button-s.png", class="loader")
+            span(class="loading_text", l10n) Loading...
 
       .row(ng-show="showInstructions && usdConnected")
         .instructions.col-md-10


### PR DESCRIPTION
Do not show "Add" button in custom gateways pages
while Ripple name is loading