### PR TITLE
[FIX] Send: fix currencies constraints (RT-3393)

### DIFF
--- a/src/js/tabs/send.controller.js
+++ b/src/js/tabs/send.controller.js
@@ -486,7 +486,12 @@ SendTab.prototype.angular = function (module)
       } else {
         // The possible currencies are the intersection of all provided currency
         // constraints.
-        currencies = _.intersection.apply(_, _.values(send.currency_choices_constraints));
+        currencies = _.values(send.currency_choices_constraints);
+        if (currencies.length == 1) {
+          currencies = currencies[0];
+        } else {
+          currencies = _.intersection.apply(_, currencies);
+        }
         currencies = _.uniq(_.compact(currencies));
 
         // create the display version of the currencies


### PR DESCRIPTION
Fix processing of currencies constraints.
When RT is loaded in browser, underscore lib gets replaced
by the lodash by something. And in the old versions of lodash
there was bug in _.intersection method (if argument is just one
array it returned this array). But in recent versions they fixed
this bug, so $scope.update_currency_choices broke.