### PR TITLE
[FIX] Trade: "My Orders" orderbooks (RT-3400)

### DIFF
--- a/src/js/tabs/trade.controller.js
+++ b/src/js/tabs/trade.controller.js
@@ -494,6 +494,11 @@ TradeTab.prototype.angular = function(module)
      */
     $scope.goto_order_currency = function() {
       if (!this.entry) return;
+      if (getOrderCurrency(this.entry) === $scope.order.currency_pair) {
+        // same pair, do nothing
+        return;
+      }
+
       var entry = this.entry;
       var order = $scope.order;
       currencyPairChangedByNonUser = true;


### PR DESCRIPTION
Advanced Trade: when switching between orderbooks
using the "My Orders" widget check if current pair
is same and do not try to switch in that case.