### PR TITLE
[TASK] add Bluzelle to dropdown (RT-3493)

### DIFF
--- a/deps/gateways.json
+++ b/deps/gateways.json
@@ -183,5 +183,12 @@
             "currencies": ["USD", "EUR"]
             }],
         "domain": "www.gatehub.net"
+    }, {
+      "name": "Bluzelle",
+      "accounts": [{
+            "address": "raBDVR7JFq3Yho2jf7mcx36sjTwpRJJrGU",
+            "currencies": ["CAD"]
+            }],
+        "domain": "bluzelle.com"
     }
 ]


### PR DESCRIPTION
add Bluzelle as a CAD currency in the Ripple Trade dropdown