### PR TITLE
[FIX] Send: check address (RT-3510)

### DIFF
--- a/src/js/directives/validators.directive.js
+++ b/src/js/directives/validators.directive.js
@@ -125,6 +125,11 @@ module.directive('rpDest', ['$q', '$timeout', '$parse', 'rpFederation', function
         var strippedValue = webutil.stripRippleAddress(value),
             address = ripple.UInt160.from_json(strippedValue);
 
+        if (typeof strippedValue !== 'string'
+          || (strippedValue.length && strippedValue[0] !== 'r')) {
+            address = ripple.UInt160.from_json();
+        }
+
         if (currentDefer) {
           // another check is pending, but it is not needed
           currentDefer.resolve(true);


### PR DESCRIPTION
Allow only canonical (staring with 'r') form of ripple addresses
to be used on send tab.